### PR TITLE
Converting JSON objects to string is fixed

### DIFF
--- a/SwiftyJSON/SwiftyJSON.swift
+++ b/SwiftyJSON/SwiftyJSON.swift
@@ -288,11 +288,11 @@ extension JSONValue: Printable {
                 }
                 index += 1
             }
-            return "[\(objectString)]"
+            return "{\(objectString)}"
         case .JInvalid:
             return "INVALID_JSON_VALUE"
             }
-    }
+  }
     
     func _printableString(indent: String) -> String {
         switch self {


### PR DESCRIPTION
JSON objects use curly braces instead of square brackets (unlike Swift dictionaries)
