### PR TITLE
SourceKitService Termination issue fix

### DIFF
--- a/SwiftyJSON/SwiftyJSON.swift
+++ b/SwiftyJSON/SwiftyJSON.swift
@@ -166,7 +166,7 @@ enum JSONValue {
         case let value as NSNull:
             self = .JNull
         case let value as NSArray:
-            var jsonValues = [JSONValue]()
+            var jsonValues = JSONValue[]()
             for possibleJsonValue : AnyObject in value {
                 let jsonValue = JSONValue(possibleJsonValue)
                 if  jsonValue {


### PR DESCRIPTION
I raised a issue in your code here

https://github.com/lingoer/SwiftyJSON/issues/22

This issue was caused by declaring the array name inside the square bracket( var jsonValues = [JSONValue]() ). Instead it should be given like ( var jsonValues = JSONValue[]() )
