### PR TITLE
Support for JSON as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ default:
 
 ```
 
+You also have the option of initializing a JSONValue object directly
+from a JSON string:
+
+```swift
+let json = JSONValue(jsonString: "[{\"x\": [2,7]}, 0]")
+if let aNumber = json[0]["x"][1].number {
+    println("The number is \(aNumber)")
+}
+```
+
 ##Error Handling
 ```swift
 let json = JSONValue(dataFromNetworking)["some_key"]["some_wrong_key"]["wrong_name"]

--- a/SwiftyJSON/SwiftyJSON.swift
+++ b/SwiftyJSON/SwiftyJSON.swift
@@ -138,21 +138,48 @@ enum JSONValue {
             return nil
         }
     }
-    
-    init (_ data: NSData!){
+
+    private static func initFromNSData(data: NSData?) -> JSONValue {
+
         if let value = data{
             var error:NSError? = nil
-            if let jsonObject : AnyObject = NSJSONSerialization.JSONObjectWithData(data, options: nil, error: &error) {
-                self = JSONValue(jsonObject)
-            }else{
-                self = JSONValue.JInvalid(NSError(domain: "JSONErrorDomain", code: 1001, userInfo: [NSLocalizedDescriptionKey:"JSON Parser Error: Invalid Raw JSON Data"]))
+            if let jsonObject : AnyObject = NSJSONSerialization.JSONObjectWithData(
+                data,
+                options: nil,
+                error: &error) {
+                return JSONValue(jsonObject)
+            } else {
+                return JSONValue.JInvalid(
+                    NSError(
+                        domain: "JSONErrorDomain",
+                        code: 1001,
+                        userInfo: [NSLocalizedDescriptionKey
+                                   :"JSON Parser Error: Invalid Raw JSON Data"]))
             }
-        }else{
-            self = JSONValue.JInvalid(NSError(domain: "JSONErrorDomain", code: 1000, userInfo: [NSLocalizedDescriptionKey:"JSON Init Error: Invalid Value Passed In init()"]))
+        } else {
+            return JSONValue.JInvalid(NSError(
+                domain: "JSONErrorDomain",
+                code: 1000,
+                userInfo: [NSLocalizedDescriptionKey
+                           :"JSON Init Error: Invalid Value Passed In init()"]))
         }
 
     }
-    
+
+    init (_ data: NSData!) {
+
+        self = JSONValue.initFromNSData(data)
+
+    }
+
+    init (jsonString: String) {
+
+        self = JSONValue.initFromNSData(
+            jsonString.dataUsingEncoding(NSUTF8StringEncoding,
+            allowLossyConversion: false))
+
+    }
+
     init (_ rawObject: AnyObject) {
         switch rawObject {
         case let value as NSNumber:

--- a/SwiftyJSONTests/SwiftyJSONTests.swift
+++ b/SwiftyJSONTests/SwiftyJSONTests.swift
@@ -136,5 +136,11 @@ class SwiftyJSONTests: XCTestCase {
         let JSON = JSONValue("http://example.com/")
         XCTAssertEqual("\"http://example.com/\"", JSON.description, "Wrong pretty value")
     }
-  
+
+    func testInitFromJSONString() {
+        let json = JSONValue(jsonString: "[{\"x\": {\"y\": [1, 2, 3]}}, {\"z\": 4}]")
+        let shouldBeTwo = json[0]["x"]["y"][1].number
+        XCTAssertEqual(2, shouldBeTwo!, "Incorrect value from JSON string")
+    }
+
 }


### PR DESCRIPTION
A JSONValue object can now be created directly from a JSON string,
without having to go through an NSData object.

This is done by providing the external parameter name jsonString to the
initializer - consistency could be improved by having named parameters
for the NSData initializer,  as well, but that would be a breaking change.
