### PR TITLE
Use BooleanType instead of LogicValue for Beta 5

### DIFF
--- a/SwiftyJSON/SwiftyJSON.swift
+++ b/SwiftyJSON/SwiftyJSON.swift
@@ -328,8 +328,8 @@ extension JSONValue: Printable {
     }
 }
 
-extension JSONValue: LogicValue {
-    func getLogicValue() -> Bool {
+extension JSONValue: BooleanType {
+    var boolValue: Bool {
         switch self {
         case .JInvalid:
             return false

--- a/SwiftyJSONTests/SwiftyJSONTests.swift
+++ b/SwiftyJSONTests/SwiftyJSONTests.swift
@@ -48,8 +48,8 @@ class SwiftyJSONTests: XCTestCase {
         XCTAssert(numberValue == 36170434)
         XCTAssert(boolValue == false)
         XCTAssert(nullValue == JSONValue.JNull)
-        XCTAssert(arrayValue)
-        XCTAssert(objectValue)
+        XCTAssert(arrayValue != nil)
+        XCTAssert(objectValue != nil)
     }
     
     func testJSONString() {


### PR DESCRIPTION
This is an update for Beta 5.  `LogicValue` has been renamed `BooleanType` and the protocol changed to be a `boolValue` property rather than the `getLogicValue` method.

Also updated the tests per the Beta 5 [release notes](https://developer.apple.com/library/prerelease/ios/documentation/swift/conceptual/swift_programming_language/RevisionHistory.html):

> Optionals no longer conform to the BooleanType (formerly LogicValue) protocol, so they 
> may no longer be used in place of boolean expressions (they must be explicitly compared with 
> v != nil). This resolves confusion around Bool? and related types, makes code more 
> explicit about what test is expected, and is more consistent with the rest of the language. 
