### PR TITLE
made JSONValue public for usage in framework APIs

### DIFF
--- a/SwiftyJSON/SwiftyJSON.swift
+++ b/SwiftyJSON/SwiftyJSON.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 
-enum JSONValue {
+public enum JSONValue {
 
     
     case JNumber(NSNumber)
@@ -247,7 +247,7 @@ enum JSONValue {
 }
 
 extension JSONValue: Printable {
-    var description: String {
+    public var description: String {
         switch self {
         case .JInvalid(let error):
             return error.localizedDescription
@@ -329,7 +329,7 @@ extension JSONValue: Printable {
 }
 
 extension JSONValue: BooleanType {
-    var boolValue: Bool {
+    public var boolValue: Bool {
         switch self {
         case .JInvalid:
             return false
@@ -343,7 +343,7 @@ extension JSONValue : Equatable {
     
 }
 
-func ==(lhs: JSONValue, rhs: JSONValue) -> Bool {
+public func ==(lhs: JSONValue, rhs: JSONValue) -> Bool {
     switch lhs {
     case .JNumber(let lvalue):
         switch rhs {


### PR DESCRIPTION
This solves issue https://github.com/lingoer/SwiftyJSON/issues/42 without making the whole class functionality public but just by making JSONValue and the corresponding required other protocol methods public.
