### PR TITLE
Added SwiftyJSON lazy wrapping

### DIFF
--- a/SwiftyJSON/SwiftyJSON.swift
+++ b/SwiftyJSON/SwiftyJSON.swift
@@ -147,6 +147,8 @@ extension JSON {
                 retDicitonary[key] = value.rawObject
             }
             return retDicitonary
+        case .PrivateRaw(let object):
+            return object
         default:
             return nil
         }


### PR DESCRIPTION
Right now JSON(object: xxx) takes O(1) time. It wraps objects into `enum JSON` lazily while accessing members and the only accessed members are wrapped. I added new `case .PrivateRaw` and `private var rawObject` - this entities are really private and will never be visible by any source code out of `enum JSON`. Some comparison functions can see it - it is just optimization to prevent rewrapping arrays and dictionaries recursively.

I really fond of your great library and hope you like laziness :)
