### PR TITLE
Making SourceKit not freak out about self.object.count being called

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -144,8 +144,10 @@ extension JSON: SequenceType{
     public var count: Int {
         get {
             switch self.type {
-            case .Array, .Dictionary:
-                return self.object.count
+            case .Array:
+                return self.arrayValue.count
+            case .Dictionary:
+                return self.dictionaryValue.count
             default:
                 return 0
             }
@@ -478,8 +480,10 @@ extension JSON: BooleanType {
             switch self.type {
             case .Bool, .Number, .String:
                 return self.object.boolValue
-            case .Array, .Dictionary:
-                return self.object.count > 0
+            case .Array:
+                return self.arrayValue.count > 0
+            case .Dictionary:
+                return self.dictionaryValue.count > 0
             case .Null:
                 return false
             default:


### PR DESCRIPTION
When using SwiftyJSON in an app i'm playing with, SourceKit was freaking out about self.object.count for some reason. Modifying the code to just use `self.arrayValue.count` and `self.dictionaryValue.count` instead seems to stop it freaking out. It's more lines of code but it makes SourceKit happy so it's worth it.
