### PR TITLE
Update SwiftyJSON.swift

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -27,12 +27,12 @@ public typealias JSONValue = JSON
 
 //MARK: - Return Error
 //The SwiftyJSON's error domain
-public let ErrorDomain: String! = "SwiftyJSONErrorDomain"
+public let ErrorDomain = "SwiftyJSONErrorDomain"
 //The error code
-public let ErrorUnsupportedType: Int! = 999
-public let ErrorIndexOutOfBounds: Int! = 900
-public let ErrorWrongType: Int! = 901
-public let ErrorNotExist: Int! = 500
+public let ErrorUnsupportedType = 999
+public let ErrorIndexOutOfBounds = 900
+public let ErrorWrongType = 901
+public let ErrorNotExist = 500
 
 public enum Type :Int{
     


### PR DESCRIPTION
Why were the constants marked with an exclamation point? public let variables should already be defined.
