### PR TITLE
Get number from string in JSON.number

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -545,6 +545,14 @@ extension JSON {
     public var number: NSNumber? {
         get {
             switch self.type {
+            case .String:
+                let scanner = NSScanner(string: self.object as String)
+                if scanner.scanDouble(nil){
+                    if (scanner.atEnd) {
+                        return NSNumber(double:(self.object as NSString).doubleValue)
+                    }
+                }
+                return nil
             case .Number, .Bool:
                 return self.object as? NSNumber
             default:


### PR DESCRIPTION
Added parsing of string to get optional number in JSON.number. This is to match the current non optional JSON.numberValue
