### PR TITLE
Change recommendation for Alamofire integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,14 @@ SwiftyJSON nicely wraps the result of the Alamofire JSON response handler:
 ```swift
 Alamofire.request(.GET, url, parameters: parameters)
   .responseJSON { (req, res, json, error) in
-    // Init a SwiftyJSON object using the Alamofire JSON response handler.
-    var json = JSON(json!)
-    NSLog("GET Result: \(json)")
+    if(error != nil) {
+      NSLog("Error: \(error)")
+      println(req)
+      println(res)
+    }
+    else {
+      NSLog("Success: \(url)")
+      var json = JSON(json!)
+    }
   }
 ```


### PR DESCRIPTION
Issues with recommending Alamofire-SwiftyJSON:
-  Not updated for Xcode 6.1.
-  No longer necessary as a shim to integrate Alamofire and SwiftyJSON.
- Adds another dependency that needs to be manually included and managed.

I feel that recommending a third, separate dependency is confusing and unnecessary to new users.  It's only one line to have SwiftyJSON wrap the JSON returned by Alamofire.
