### PR TITLE
Add Podspec (Correct mblsha podspec)

### DIFF
--- a/SwiftyJSON.podspec
+++ b/SwiftyJSON.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name        = "SwiftyJSON"
+  s.version     = "2.1.1"
+  s.summary     = "SwiftyJSON makes it easy to deal with JSON data in Swift"
+  s.homepage    = "https://github.com/SwiftyJSON/SwiftyJSON"
+  s.license     = { :type => "MIT" }
+  s.authors     = { "lingoer" => "lingoerer@gmail.com", "tangplin" => "tangplin@gmail.com" }
+
+  s.osx.deployment_target = "10.9"
+  s.ios.deployment_target = "7.0"
+  s.source   = { :git => "https://github.com/SwiftyJSON/SwiftyJSON.git", :tag => "2.1.1" }
+  s.source_files = "Source/*.swift"
+end


### PR DESCRIPTION
This is a podspec to be used with CocoaPods 0.36.0 (Currently in alpha)
Please see CocoaPods/CocoaPods#2835 for more info. It was validated using the linter check (pod spec lint).

Gemfile for testing CocoaPods 0.36.0.pre

``` ruby
source 'https://rubygems.org'

gem 'cocoapods', :git => 'https://github.com/CocoaPods/CocoaPods.git', :branch => 'swift'
gem 'cocoapods-core', :git => 'https://github.com/CocoaPods/Core.git', :branch => 'swift'
gem 'xcodeproj',  :git => "https://github.com/CocoaPods/Xcodeproj.git", :branch => 'master'
gem 'claide',  :git => 'https://github.com/CocoaPods/CLAide.git'
```

Thanks @mblsha for the base podspec
