### PR TITLE
Added read option for date strings

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -889,6 +889,18 @@ extension JSON {
     }
 }
 
+//MARK: - Date (read only)
+extension JSON {
+    public func date(dateFormatter: NSDateFormatter) -> NSDate? {
+        if let string = self.string {
+            if let date = dateFormatter.dateFromString(string) {
+                return date
+            }
+        }
+        return nil
+    }
+}
+
 //MARK: - Comparable
 extension JSON: Comparable {}
 


### PR DESCRIPTION
I agree with https://github.com/SwiftyJSON/SwiftyJSON/pull/87 and https://github.com/SwiftyJSON/SwiftyJSON/pull/85 that SwiftyJSON lacks of date support which nearly everyone using JSON APIs will need at some point and that SwiftyJSON should support dates somehow.

But I also understand @tangplin's answer that there are too many different formats for dates in JSON APIs. So what about the idea to not deeply integrate dates into SwiftyJSON but at least add a helper method that makes getting dates from JSON objects much easier.

I have added an example implementation of what this could look like for dates formatted in String type. The user of SwiftyJSON would still need to provide the correct date formatter for the API he/she is using which solves the problem with too many formats (at least for String formats, but one could of course add support for Number formats as well).
