### PR TITLE
Fix access modificator of isEmpty property

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -135,7 +135,7 @@ public struct JSON {
 extension JSON: SequenceType{
     
     /// If `type` is `.Array` or `.Dictionary`, return `array.empty` or `dictonary.empty` otherwise return `false`.
-    var isEmpty: Bool {
+    public var isEmpty: Bool {
         get {
             switch self.type {
             case .Array:


### PR DESCRIPTION
If you include SwiftyJSON as project, you won't be able to access to this property
