### PR TITLE
Prefixed "SequenceType" extension with Module name

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -132,7 +132,7 @@ public struct JSON {
 }
 
 // MARK: - SequenceType
-extension JSON: SequenceType{
+extension JSON : Swift.SequenceType {
     
     /// If `type` is `.Array` or `.Dictionary`, return `array.empty` or `dictonary.empty` otherwise return `false`.
     public var isEmpty: Bool {


### PR DESCRIPTION
In my project I found the extension of JSON type with Swift protocol "SequenceType", to conflict with a type using the same name in another library (named FlipView). This pull request just fix this and other potential type conflict prefixing the extension with the Swift module.