### PR TITLE
Fixed the broken Carthage OS X Support.

### DIFF
--- a/Source/Info-OSX.plist
+++ b/Source/Info-OSX.plist
@@ -5,13 +5,13 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.swiftyjson.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -209,9 +209,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		2E4FEFDA19575BE100351305 /* SwiftyJSON */ = {
+		2E4FEFDA19575BE100351305 /* SwiftyJSON iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2E4FEFF119575BE100351305 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */;
+			buildConfigurationList = 2E4FEFF119575BE100351305 /* Build configuration list for PBXNativeTarget "SwiftyJSON iOS" */;
 			buildPhases = (
 				2E4FEFD619575BE100351305 /* Sources */,
 				2E4FEFD719575BE100351305 /* Frameworks */,
@@ -222,7 +222,7 @@
 			);
 			dependencies = (
 			);
-			name = SwiftyJSON;
+			name = "SwiftyJSON iOS";
 			productName = SwiftyJSON;
 			productReference = 2E4FEFDB19575BE100351305 /* SwiftyJSON.framework */;
 			productType = "com.apple.product-type.framework";
@@ -245,9 +245,9 @@
 			productReference = 2E4FEFE619575BE100351305 /* SwiftyJSONTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSONOSX */ = {
+		4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSON OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4EC1C1DC1A0C1A2D0026ED0B /* Build configuration list for PBXNativeTarget "SwiftyJSONOSX" */;
+			buildConfigurationList = 4EC1C1DC1A0C1A2D0026ED0B /* Build configuration list for PBXNativeTarget "SwiftyJSON OSX" */;
 			buildPhases = (
 				4EC1C1C41A0C1A2D0026ED0B /* Sources */,
 				4EC1C1C51A0C1A2D0026ED0B /* Frameworks */,
@@ -258,7 +258,7 @@
 			);
 			dependencies = (
 			);
-			name = SwiftyJSONOSX;
+			name = "SwiftyJSON OSX";
 			productName = SwiftyJSONOSX;
 			productReference = 4EC1C1C91A0C1A2D0026ED0B /* SwiftyJSON.framework */;
 			productType = "com.apple.product-type.framework";
@@ -316,9 +316,9 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				2E4FEFDA19575BE100351305 /* SwiftyJSON */,
+				2E4FEFDA19575BE100351305 /* SwiftyJSON iOS */,
 				2E4FEFE519575BE100351305 /* SwiftyJSONTests */,
-				4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSONOSX */,
+				4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSON OSX */,
 				4EC1C1D21A0C1A2D0026ED0B /* SwiftyJSONOSXTests */,
 			);
 		};
@@ -419,12 +419,12 @@
 /* Begin PBXTargetDependency section */
 		2E4FEFE919575BE100351305 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2E4FEFDA19575BE100351305 /* SwiftyJSON */;
+			target = 2E4FEFDA19575BE100351305 /* SwiftyJSON iOS */;
 			targetProxy = 2E4FEFE819575BE100351305 /* PBXContainerItemProxy */;
 		};
 		4EC1C1D61A0C1A2D0026ED0B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSONOSX */;
+			target = 4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSON OSX */;
 			targetProxy = 4EC1C1D51A0C1A2D0026ED0B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -530,7 +530,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = SwiftyJSON;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -548,7 +548,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = SwiftyJSON;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -588,7 +588,6 @@
 		4EC1C1DD1A0C1A2D0026ED0B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -613,7 +612,6 @@
 		4EC1C1DE1A0C1A2D0026ED0B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "3rd Party Mac Developer Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -685,7 +683,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2E4FEFF119575BE100351305 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */ = {
+		2E4FEFF119575BE100351305 /* Build configuration list for PBXNativeTarget "SwiftyJSON iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2E4FEFF219575BE100351305 /* Debug */,
@@ -703,7 +701,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4EC1C1DC1A0C1A2D0026ED0B /* Build configuration list for PBXNativeTarget "SwiftyJSONOSX" */ = {
+		4EC1C1DC1A0C1A2D0026ED0B /* Build configuration list for PBXNativeTarget "SwiftyJSON OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4EC1C1DD1A0C1A2D0026ED0B /* Debug */,

--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -7,25 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		030B6CCE1A6E16E900C2D4F1 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 030B6CC31A6E16E800C2D4F1 /* SwiftyJSON.framework */; };
+		030B6CDD1A6E172B00C2D4F1 /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		030B6CDE1A6E172B00C2D4F1 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8491E1D19CD6DAE00CCFAE6 /* SwiftyJSON.swift */; };
 		2E4FEFE119575BE100351305 /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2E4FEFE719575BE100351305 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E4FEFDB19575BE100351305 /* SwiftyJSON.framework */; };
-		4EC1C1D41A0C1A2D0026ED0B /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EC1C1C91A0C1A2D0026ED0B /* SwiftyJSON.framework */; };
-		4EC1C1E21A0C1A6E0026ED0B /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4EC1C1E31A0C1A750026ED0B /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8491E1D19CD6DAE00CCFAE6 /* SwiftyJSON.swift */; };
-		4EC1C1E41A0C1A800026ED0B /* Tests.json in Resources */ = {isa = PBXBuildFile; fileRef = A885D1DA19CFCFF0002FD4C3 /* Tests.json */; };
-		4EC1C1E51A0C1A800026ED0B /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86BAA0D19EBC32B009EAAEB /* PerformanceTests.swift */; };
-		4EC1C1E61A0C1A800026ED0B /* BaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A885D1D119CF1EE6002FD4C3 /* BaseTests.swift */; };
-		4EC1C1E71A0C1A800026ED0B /* SequenceTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87080E319E3C2A600CDE086 /* SequenceTypeTests.swift */; };
-		4EC1C1E81A0C1A800026ED0B /* PrintableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819C4A019E37FC600ADCC3D /* PrintableTests.swift */; };
-		4EC1C1E91A0C1A800026ED0B /* SubscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819C49E19E2EE5B00ADCC3D /* SubscriptTests.swift */; };
-		4EC1C1EA1A0C1A800026ED0B /* LiteralConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819C49619E1A7DD00ADCC3D /* LiteralConvertibleTests.swift */; };
-		4EC1C1EB1A0C1A800026ED0B /* RawRepresentableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819C49819E1B10300ADCC3D /* RawRepresentableTests.swift */; };
-		4EC1C1EC1A0C1A800026ED0B /* ComparableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87080E519E3DF7800CDE086 /* ComparableTests.swift */; };
-		4EC1C1ED1A0C1A800026ED0B /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87080E919E43C0700CDE086 /* StringTests.swift */; };
-		4EC1C1EE1A0C1A800026ED0B /* NumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87080E719E439DA00CDE086 /* NumberTests.swift */; };
-		4EC1C1EF1A0C1A800026ED0B /* RawTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A863BE2719EED46F0092A41F /* RawTests.swift */; };
-		4EC1C1F01A0C1A800026ED0B /* DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B66C8B19E51D6500540692 /* DictionaryTests.swift */; };
-		4EC1C1F11A0C1A800026ED0B /* ArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B66C8D19E52F4200540692 /* ArrayTests.swift */; };
 		A819C49719E1A7DD00ADCC3D /* LiteralConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819C49619E1A7DD00ADCC3D /* LiteralConvertibleTests.swift */; };
 		A819C49919E1B10300ADCC3D /* RawRepresentableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819C49819E1B10300ADCC3D /* RawRepresentableTests.swift */; };
 		A819C49F19E2EE5B00ADCC3D /* SubscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819C49E19E2EE5B00ADCC3D /* SubscriptTests.swift */; };
@@ -44,6 +30,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		030B6CCF1A6E16E900C2D4F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E4FEFD219575BE100351305 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 030B6CC21A6E16E800C2D4F1;
+			remoteInfo = "SwiftyJSON OSX";
+		};
 		2E4FEFE819575BE100351305 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2E4FEFD219575BE100351305 /* Project object */;
@@ -51,22 +44,16 @@
 			remoteGlobalIDString = 2E4FEFDA19575BE100351305;
 			remoteInfo = SwiftyJSON;
 		};
-		4EC1C1D51A0C1A2D0026ED0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2E4FEFD219575BE100351305 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4EC1C1C81A0C1A2D0026ED0B;
-			remoteInfo = SwiftyJSONOSX;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		030B6CC31A6E16E800C2D4F1 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		030B6CCD1A6E16E900C2D4F1 /* SwiftyJSON OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftyJSON OSXTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		030B6CDC1A6E171D00C2D4F1 /* Info-OSX.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-OSX.plist"; sourceTree = "<group>"; };
 		2E4FEFDB19575BE100351305 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E4FEFDF19575BE100351305 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2E4FEFE019575BE100351305 /* SwiftyJSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftyJSON.h; sourceTree = "<group>"; };
 		2E4FEFE619575BE100351305 /* SwiftyJSONTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftyJSONTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		4EC1C1C91A0C1A2D0026ED0B /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4EC1C1D31A0C1A2D0026ED0B /* SwiftyJSONOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftyJSONOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A819C49619E1A7DD00ADCC3D /* LiteralConvertibleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiteralConvertibleTests.swift; sourceTree = "<group>"; };
 		A819C49819E1B10300ADCC3D /* RawRepresentableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawRepresentableTests.swift; sourceTree = "<group>"; };
 		A819C49E19E2EE5B00ADCC3D /* SubscriptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptTests.swift; sourceTree = "<group>"; };
@@ -86,6 +73,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		030B6CBF1A6E16E800C2D4F1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		030B6CCA1A6E16E900C2D4F1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				030B6CCE1A6E16E900C2D4F1 /* SwiftyJSON.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2E4FEFD719575BE100351305 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -98,21 +100,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				2E4FEFE719575BE100351305 /* SwiftyJSON.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4EC1C1C51A0C1A2D0026ED0B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4EC1C1D01A0C1A2D0026ED0B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4EC1C1D41A0C1A2D0026ED0B /* SwiftyJSON.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,8 +120,8 @@
 			children = (
 				2E4FEFDB19575BE100351305 /* SwiftyJSON.framework */,
 				2E4FEFE619575BE100351305 /* SwiftyJSONTests.xctest */,
-				4EC1C1C91A0C1A2D0026ED0B /* SwiftyJSON.framework */,
-				4EC1C1D31A0C1A2D0026ED0B /* SwiftyJSONOSXTests.xctest */,
+				030B6CC31A6E16E800C2D4F1 /* SwiftyJSON.framework */,
+				030B6CCD1A6E16E900C2D4F1 /* SwiftyJSON OSXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -152,6 +139,7 @@
 		2E4FEFDE19575BE100351305 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				030B6CDC1A6E171D00C2D4F1 /* Info-OSX.plist */,
 				2E4FEFDF19575BE100351305 /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -190,6 +178,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		030B6CC01A6E16E800C2D4F1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				030B6CDD1A6E172B00C2D4F1 /* SwiftyJSON.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2E4FEFD819575BE100351305 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -198,17 +194,45 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4EC1C1C61A0C1A2D0026ED0B /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4EC1C1E21A0C1A6E0026ED0B /* SwiftyJSON.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		030B6CC21A6E16E800C2D4F1 /* SwiftyJSON OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 030B6CD61A6E16E900C2D4F1 /* Build configuration list for PBXNativeTarget "SwiftyJSON OSX" */;
+			buildPhases = (
+				030B6CBE1A6E16E800C2D4F1 /* Sources */,
+				030B6CBF1A6E16E800C2D4F1 /* Frameworks */,
+				030B6CC01A6E16E800C2D4F1 /* Headers */,
+				030B6CC11A6E16E800C2D4F1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SwiftyJSON OSX";
+			productName = "SwiftyJSON OSX";
+			productReference = 030B6CC31A6E16E800C2D4F1 /* SwiftyJSON.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		030B6CCC1A6E16E900C2D4F1 /* SwiftyJSON OSXTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 030B6CD91A6E16E900C2D4F1 /* Build configuration list for PBXNativeTarget "SwiftyJSON OSXTests" */;
+			buildPhases = (
+				030B6CC91A6E16E900C2D4F1 /* Sources */,
+				030B6CCA1A6E16E900C2D4F1 /* Frameworks */,
+				030B6CCB1A6E16E900C2D4F1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				030B6CD01A6E16E900C2D4F1 /* PBXTargetDependency */,
+			);
+			name = "SwiftyJSON OSXTests";
+			productName = "SwiftyJSON OSXTests";
+			productReference = 030B6CCD1A6E16E900C2D4F1 /* SwiftyJSON OSXTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		2E4FEFDA19575BE100351305 /* SwiftyJSON iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2E4FEFF119575BE100351305 /* Build configuration list for PBXNativeTarget "SwiftyJSON iOS" */;
@@ -245,42 +269,6 @@
 			productReference = 2E4FEFE619575BE100351305 /* SwiftyJSONTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSON OSX */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4EC1C1DC1A0C1A2D0026ED0B /* Build configuration list for PBXNativeTarget "SwiftyJSON OSX" */;
-			buildPhases = (
-				4EC1C1C41A0C1A2D0026ED0B /* Sources */,
-				4EC1C1C51A0C1A2D0026ED0B /* Frameworks */,
-				4EC1C1C61A0C1A2D0026ED0B /* Headers */,
-				4EC1C1C71A0C1A2D0026ED0B /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "SwiftyJSON OSX";
-			productName = SwiftyJSONOSX;
-			productReference = 4EC1C1C91A0C1A2D0026ED0B /* SwiftyJSON.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		4EC1C1D21A0C1A2D0026ED0B /* SwiftyJSONOSXTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4EC1C1DF1A0C1A2D0026ED0B /* Build configuration list for PBXNativeTarget "SwiftyJSONOSXTests" */;
-			buildPhases = (
-				4EC1C1CF1A0C1A2D0026ED0B /* Sources */,
-				4EC1C1D01A0C1A2D0026ED0B /* Frameworks */,
-				4EC1C1D11A0C1A2D0026ED0B /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				4EC1C1D61A0C1A2D0026ED0B /* PBXTargetDependency */,
-			);
-			name = SwiftyJSONOSXTests;
-			productName = SwiftyJSONOSXTests;
-			productReference = 4EC1C1D31A0C1A2D0026ED0B /* SwiftyJSONOSXTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -289,18 +277,18 @@
 			attributes = {
 				LastUpgradeCheck = 0600;
 				TargetAttributes = {
+					030B6CC21A6E16E800C2D4F1 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+					030B6CCC1A6E16E900C2D4F1 = {
+						CreatedOnToolsVersion = 6.2;
+					};
 					2E4FEFDA19575BE100351305 = {
 						CreatedOnToolsVersion = 6.0;
 					};
 					2E4FEFE519575BE100351305 = {
 						CreatedOnToolsVersion = 6.0;
 						TestTargetID = 2E4FEFDA19575BE100351305;
-					};
-					4EC1C1C81A0C1A2D0026ED0B = {
-						CreatedOnToolsVersion = 6.1;
-					};
-					4EC1C1D21A0C1A2D0026ED0B = {
-						CreatedOnToolsVersion = 6.1;
 					};
 				};
 			};
@@ -318,13 +306,27 @@
 			targets = (
 				2E4FEFDA19575BE100351305 /* SwiftyJSON iOS */,
 				2E4FEFE519575BE100351305 /* SwiftyJSONTests */,
-				4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSON OSX */,
-				4EC1C1D21A0C1A2D0026ED0B /* SwiftyJSONOSXTests */,
+				030B6CC21A6E16E800C2D4F1 /* SwiftyJSON OSX */,
+				030B6CCC1A6E16E900C2D4F1 /* SwiftyJSON OSXTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		030B6CC11A6E16E800C2D4F1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		030B6CCB1A6E16E900C2D4F1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2E4FEFD919575BE100351305 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -340,24 +342,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4EC1C1C71A0C1A2D0026ED0B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4EC1C1D11A0C1A2D0026ED0B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4EC1C1E41A0C1A800026ED0B /* Tests.json in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		030B6CBE1A6E16E800C2D4F1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				030B6CDE1A6E172B00C2D4F1 /* SwiftyJSON.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		030B6CC91A6E16E900C2D4F1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2E4FEFD619575BE100351305 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -386,50 +388,104 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4EC1C1C41A0C1A2D0026ED0B /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4EC1C1E31A0C1A750026ED0B /* SwiftyJSON.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4EC1C1CF1A0C1A2D0026ED0B /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4EC1C1E71A0C1A800026ED0B /* SequenceTypeTests.swift in Sources */,
-				4EC1C1EC1A0C1A800026ED0B /* ComparableTests.swift in Sources */,
-				4EC1C1EE1A0C1A800026ED0B /* NumberTests.swift in Sources */,
-				4EC1C1EB1A0C1A800026ED0B /* RawRepresentableTests.swift in Sources */,
-				4EC1C1E61A0C1A800026ED0B /* BaseTests.swift in Sources */,
-				4EC1C1F01A0C1A800026ED0B /* DictionaryTests.swift in Sources */,
-				4EC1C1E51A0C1A800026ED0B /* PerformanceTests.swift in Sources */,
-				4EC1C1EA1A0C1A800026ED0B /* LiteralConvertibleTests.swift in Sources */,
-				4EC1C1E81A0C1A800026ED0B /* PrintableTests.swift in Sources */,
-				4EC1C1ED1A0C1A800026ED0B /* StringTests.swift in Sources */,
-				4EC1C1EF1A0C1A800026ED0B /* RawTests.swift in Sources */,
-				4EC1C1F11A0C1A800026ED0B /* ArrayTests.swift in Sources */,
-				4EC1C1E91A0C1A800026ED0B /* SubscriptTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		030B6CD01A6E16E900C2D4F1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 030B6CC21A6E16E800C2D4F1 /* SwiftyJSON OSX */;
+			targetProxy = 030B6CCF1A6E16E900C2D4F1 /* PBXContainerItemProxy */;
+		};
 		2E4FEFE919575BE100351305 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2E4FEFDA19575BE100351305 /* SwiftyJSON iOS */;
 			targetProxy = 2E4FEFE819575BE100351305 /* PBXContainerItemProxy */;
 		};
-		4EC1C1D61A0C1A2D0026ED0B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 4EC1C1C81A0C1A2D0026ED0B /* SwiftyJSON OSX */;
-			targetProxy = 4EC1C1D51A0C1A2D0026ED0B /* PBXContainerItemProxy */;
-		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		030B6CD71A6E16E900C2D4F1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info-OSX.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		030B6CD81A6E16E900C2D4F1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info-OSX.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		030B6CDA1A6E16E900C2D4F1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "SwiftyJSON OSXTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		030B6CDB1A6E16E900C2D4F1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "SwiftyJSON OSXTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		2E4FEFEF19575BE100351305 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -585,95 +641,25 @@
 			};
 			name = Release;
 		};
-		4EC1C1DD1A0C1A2D0026ED0B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_VERSION = A;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_MODULE_NAME = SwiftyJSON;
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		4EC1C1DE1A0C1A2D0026ED0B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_MODULE_NAME = SwiftyJSON;
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		4EC1C1E01A0C1A2D0026ED0B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Debug;
-		};
-		4EC1C1E11A0C1A2D0026ED0B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "3rd Party Mac Developer Application";
-				COMBINE_HIDPI_IMAGES = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		030B6CD61A6E16E900C2D4F1 /* Build configuration list for PBXNativeTarget "SwiftyJSON OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				030B6CD71A6E16E900C2D4F1 /* Debug */,
+				030B6CD81A6E16E900C2D4F1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		030B6CD91A6E16E900C2D4F1 /* Build configuration list for PBXNativeTarget "SwiftyJSON OSXTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				030B6CDA1A6E16E900C2D4F1 /* Debug */,
+				030B6CDB1A6E16E900C2D4F1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		2E4FEFD519575BE100351305 /* Build configuration list for PBXProject "SwiftyJSON" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -697,24 +683,6 @@
 			buildConfigurations = (
 				2E4FEFF519575BE100351305 /* Debug */,
 				2E4FEFF619575BE100351305 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		4EC1C1DC1A0C1A2D0026ED0B /* Build configuration list for PBXNativeTarget "SwiftyJSON OSX" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4EC1C1DD1A0C1A2D0026ED0B /* Debug */,
-				4EC1C1DE1A0C1A2D0026ED0B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		4EC1C1DF1A0C1A2D0026ED0B /* Build configuration list for PBXNativeTarget "SwiftyJSONOSXTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4EC1C1E01A0C1A2D0026ED0B /* Debug */,
-				4EC1C1E11A0C1A2D0026ED0B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON OSX.xcscheme
+++ b/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON OSX.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0620"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4EC1C1C81A0C1A2D0026ED0B"
+               BuildableName = "SwiftyJSON.framework"
+               BlueprintName = "SwiftyJSON OSX"
+               ReferencedContainer = "container:SwiftyJSON.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4EC1C1D21A0C1A2D0026ED0B"
+               BuildableName = "SwiftyJSONOSXTests.xctest"
+               BlueprintName = "SwiftyJSONOSXTests"
+               ReferencedContainer = "container:SwiftyJSON.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4EC1C1D21A0C1A2D0026ED0B"
+               BuildableName = "SwiftyJSONOSXTests.xctest"
+               BlueprintName = "SwiftyJSONOSXTests"
+               ReferencedContainer = "container:SwiftyJSON.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4EC1C1C81A0C1A2D0026ED0B"
+            BuildableName = "SwiftyJSON.framework"
+            BlueprintName = "SwiftyJSON OSX"
+            ReferencedContainer = "container:SwiftyJSON.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4EC1C1C81A0C1A2D0026ED0B"
+            BuildableName = "SwiftyJSON.framework"
+            BlueprintName = "SwiftyJSON OSX"
+            ReferencedContainer = "container:SwiftyJSON.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4EC1C1C81A0C1A2D0026ED0B"
+            BuildableName = "SwiftyJSON.framework"
+            BlueprintName = "SwiftyJSON OSX"
+            ReferencedContainer = "container:SwiftyJSON.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON OSX.xcscheme
+++ b/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON OSX.xcscheme
@@ -14,8 +14,8 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4EC1C1C81A0C1A2D0026ED0B"
-               BuildableName = "SwiftyJSON.framework"
+               BlueprintIdentifier = "030B6CC21A6E16E800C2D4F1"
+               BuildableName = "SwiftyJSON OSX.framework"
                BlueprintName = "SwiftyJSON OSX"
                ReferencedContainer = "container:SwiftyJSON.xcodeproj">
             </BuildableReference>
@@ -56,8 +56,8 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4EC1C1C81A0C1A2D0026ED0B"
-            BuildableName = "SwiftyJSON.framework"
+            BlueprintIdentifier = "030B6CC21A6E16E800C2D4F1"
+            BuildableName = "SwiftyJSON OSX.framework"
             BlueprintName = "SwiftyJSON OSX"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
@@ -75,8 +75,8 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4EC1C1C81A0C1A2D0026ED0B"
-            BuildableName = "SwiftyJSON.framework"
+            BlueprintIdentifier = "030B6CC21A6E16E800C2D4F1"
+            BuildableName = "SwiftyJSON OSX.framework"
             BlueprintName = "SwiftyJSON OSX"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
@@ -93,8 +93,8 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4EC1C1C81A0C1A2D0026ED0B"
-            BuildableName = "SwiftyJSON.framework"
+            BlueprintIdentifier = "030B6CC21A6E16E800C2D4F1"
+            BuildableName = "SwiftyJSON OSX.framework"
             BlueprintName = "SwiftyJSON OSX"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>

--- a/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON iOS.xcscheme
+++ b/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON iOS.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2E4FEFDA19575BE100351305"
-               BuildableName = "SwiftyJSON.framework"
-               BlueprintName = "SwiftyJSON"
+               BuildableName = "SwiftyJSON iOS.framework"
+               BlueprintName = "SwiftyJSON iOS"
                ReferencedContainer = "container:SwiftyJSON.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -57,8 +57,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2E4FEFDA19575BE100351305"
-            BuildableName = "SwiftyJSON.framework"
-            BlueprintName = "SwiftyJSON"
+            BuildableName = "SwiftyJSON iOS.framework"
+            BlueprintName = "SwiftyJSON iOS"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -76,8 +76,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2E4FEFDA19575BE100351305"
-            BuildableName = "SwiftyJSON.framework"
-            BlueprintName = "SwiftyJSON"
+            BuildableName = "SwiftyJSON iOS.framework"
+            BlueprintName = "SwiftyJSON iOS"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -94,8 +94,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2E4FEFDA19575BE100351305"
-            BuildableName = "SwiftyJSON.framework"
-            BlueprintName = "SwiftyJSON"
+            BuildableName = "SwiftyJSON iOS.framework"
+            BlueprintName = "SwiftyJSON iOS"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON iOS.xcscheme
+++ b/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2E4FEFDA19575BE100351305"
-               BuildableName = "SwiftyJSON iOS.framework"
+               BuildableName = "SwiftyJSON.framework"
                BlueprintName = "SwiftyJSON iOS"
                ReferencedContainer = "container:SwiftyJSON.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2E4FEFDA19575BE100351305"
-            BuildableName = "SwiftyJSON iOS.framework"
+            BuildableName = "SwiftyJSON.framework"
             BlueprintName = "SwiftyJSON iOS"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
@@ -76,7 +76,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2E4FEFDA19575BE100351305"
-            BuildableName = "SwiftyJSON iOS.framework"
+            BuildableName = "SwiftyJSON.framework"
             BlueprintName = "SwiftyJSON iOS"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
@@ -94,7 +94,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2E4FEFDA19575BE100351305"
-            BuildableName = "SwiftyJSON iOS.framework"
+            BuildableName = "SwiftyJSON.framework"
             BlueprintName = "SwiftyJSON iOS"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
It's look like SwiftyJSON for OS X is not building correctly when using Carthage. So I modify the scheme of the OS X a little bit. Now I can run carthage and build SwiftyJSON for OS X.

Cheers.