### PR TITLE
Casting to NSDictionary instead of [String : AnyObject]

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -110,7 +110,7 @@ public struct JSON {
                 _type = .Null
             case let array as [AnyObject]:
                 _type = .Array
-            case let dictionary as [String : AnyObject]:
+            case let dictionary as NSDictionary:
                 _type = .Dictionary
             default:
                 _type = .Unknown


### PR DESCRIPTION
https://github.com/SwiftyJSON/SwiftyJSON/issues/102
I had have same probrem.
I examined the issue with Time Profiler Instruments, and found that casting to [String : AnyObject] is very slow.
On a trial basis , I changed to cast to NSDictionary, and it improved perfromance.
There was no probrem in unit testing.

By the way , this is my first pull request in my github life.Please forgive me if something wrong.And sorry for my poor English.