### PR TITLE
Fix tests not building for 32-bit [Xcode 6.3]

### DIFF
--- a/Tests/BaseTests.swift
+++ b/Tests/BaseTests.swift
@@ -111,7 +111,7 @@ class BaseTests: XCTestCase {
         let created_at = json[0]["created_at"].string
         let id_str = json[0]["id_str"].string
         let favorited = json[0]["favorited"].bool
-        let id = json[0]["id"].int
+        let id = json[0]["id"].int64
         let in_reply_to_user_id_str = json[0]["in_reply_to_user_id_str"]
         XCTAssertEqual(created_at!, "Tue Aug 28 21:16:23 +0000 2012")
         XCTAssertEqual(id_str!,"240558470661799936")


### PR DESCRIPTION
Changes the type of the `id` constant in `BaseTests.testJSONDoesProduceValidWithCorrectKeyPath()` to be of the type `Int64` instead.

When compiling for 32-bit the unit tests fails (e.g. set target device to _“iPhone 5 (8.1)”_ or _“iPhone 5 (8.3)”_):
```
CompileSwift normal i386 /Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/BaseTests.swift
    cd /Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON
    /Applications/Xcode-Beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/NumberTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/SequenceTypeTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/PerformanceTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/RawRepresentableTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/SubscriptTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/RawTests.swift" -primary-file "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/BaseTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/ArrayTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/DictionaryTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/PrintableTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/LiteralConvertibleTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/StringTests.swift" "/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/ComparableTests.swift" -target i386-apple-ios8.0 -enable-objc-interop -sdk /Applications/Xcode-Beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.3.sdk -I /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Products/Release-iphonesimulator -F /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Products/Release-iphonesimulator -F /Applications/Xcode-Beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.3.sdk/Developer/Library/Frameworks -F /Applications/Xcode-Beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks -F /Applications/Xcode-Beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.3.sdk/Developer/Library/Frameworks -g -module-cache-path /Users/aron/Library/Developer/Xcode/DerivedData/ModuleCache -Xcc -I/Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/SwiftyJSONTests-generated-files.hmap -Xcc -I/Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/SwiftyJSONTests-own-target-headers.hmap -Xcc -I/Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/SwiftyJSONTests-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/SwiftyJSONTests-project-headers.hmap -Xcc -I/Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Products/Release-iphonesimulator/include -Xcc -I/Applications/Xcode-Beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include -Xcc -I/Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/DerivedSources/i386 -Xcc -I/Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/DerivedSources -Xcc "-working-directory/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON" -emit-module-doc-path /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/Objects-normal/i386/BaseTests~partial.swiftdoc -O -module-name SwiftyJSONTests -emit-module-path /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/Objects-normal/i386/BaseTests~partial.swiftmodule -serialize-diagnostics-path /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/Objects-normal/i386/BaseTests.dia -emit-dependencies-path /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/Objects-normal/i386/BaseTests.d -emit-reference-dependencies-path /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/Objects-normal/i386/BaseTests.swiftdeps -o /Users/aron/Library/Developer/Xcode/DerivedData/SwiftyJSON-akcxpmikzvrgbbfinezftemururx/Build/Intermediates/SwiftyJSON.build/Release-iphonesimulator/SwiftyJSONTests.build/Objects-normal/i386/BaseTests.o
/Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/BaseTests.swift:119:28: error: integer literal overflows when stored into 'Int'
        XCTAssertEqual(id!,240558470661799936)
```

The failure is in [BaseTests.swift on line 119](https://github.com/SwiftyJSON/SwiftyJSON/blob/xcode6.3/Tests/BaseTests.swift#L119) and is due to `240558470661799936` being a lot larger than `Int.max` on 32-bit systems.
```swift
let id = json[0]["id"].int
[…]
XCTAssertEqual(id!,240558470661799936)
```

The maximum positive number supported is `2^31-1 = 2147483647`. So let’s change the type of `id` to be `Int64` instead so we always work with a 64-bit integer.