### PR TITLE
Change to not build test when building iOS framework target [Xcode 6.3 + external tools]

### DIFF
--- a/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON iOS.xcscheme
+++ b/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON iOS.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">


### PR DESCRIPTION
Disables building the iOS tests target when building the iOS framework target. Was causing external tools (e.g. Carthage) to fail to build the iOS framework target due to the Tests code having compile time bug (#152).

- CMD+U still works and so forth.
- Travis-CI should still work as it’s explicitly triggering the `test` action.

_Cartfile_
```ogdl
github "SwiftyJSON/SwiftyJSON" "xcode6.3"
```

_Output_
```shell
$ carthage update --platform iOS
*** Fetching SwiftyJSON
*** Checking out SwiftyJSON at "0691445da4c4a94484621919c347d7b69f9598fe"
*** xcodebuild output can be found in /var/folders/52/kcvl_20s7k9_cs0bc4rmr0680000gn/T/carthage-xcodebuild.NhZQgq.log
*** Building scheme "SwiftyJSON iOS" in SwiftyJSON.xcworkspace
2015-02-15 15:43:02.166 xcodebuild[24427:1667147]  DVTAssertions: Warning in /SourceCache/DVTiOSFrameworks/DVTiOSFrameworks-7514.1/DTDeviceKitBase/DTDKRemoteDeviceDataListener.m:79
Details:  Running against an old version of MobileDevice; some interaction with proxied devices may be unavailable.
Object:   <DTDKRemoteDeviceDataListener: 0x7fd3ae142fd0>
Method:   -listenerThreadImplementation
Thread:   <NSThread: 0x7fd3ae146780>{number = 2, name = (null)}
Please file a bug at http://bugreport.apple.com with this warning message and any useful information you can provide.
** BUILD FAILED **


The following build commands failed:
	CompileSwift normal i386 /Users/aron/SomeProject/Carthage/Checkouts/SwiftyJSON/Tests/BaseTests.swift
	CompileSwiftSources normal i386 com.apple.xcode.tools.swift.compiler
(2 failures)
```