### PR TITLE
Fixed a bug when accessing a value directly via a string subscript when the current object is a dictionary

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -247,7 +247,7 @@ extension JSON {
         get {
             var returnJSON = JSON.nullJSON
             if self.type == .Dictionary {
-                if let object_: AnyObject = self.object[key] {
+                if let object_: AnyObject = self.dictionaryObject?[key] {
                     returnJSON = JSON(object_)
                 } else {
                     returnJSON._error = NSError(domain: ErrorDomain, code: ErrorNotExist, userInfo: [NSLocalizedDescriptionKey: "Dictionary[\"\(key)\"] does not exist"])


### PR DESCRIPTION
I first noticed this in the latest Xcode 6.3 beta 3. It would appear that trying to do a subscript of a `Dictionary` casted as an `AnyObject` does not return the correct value