### PR TITLE
Updated code signing identities for OSX target and tests

### DIFF
--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -592,7 +592,7 @@
 		9C7DFC6F1A9102BD005AA3F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -616,7 +616,7 @@
 		9C7DFC701A9102BD005AA3F7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -637,6 +637,7 @@
 		9C7DFC721A9102BD005AA3F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -657,6 +658,7 @@
 		9C7DFC731A9102BD005AA3F7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (


### PR DESCRIPTION
In order to properly support Carthage and CocoaPods at the same time with cross-platform targets, the code signing identities need to be modified a bit to make sure everyone can build SwiftyJSON using Carthage.

To properly support Carthage, iOS targets and tests need to code sign as `iPhone Developer`. This is due to the fact that Xcode *requires* them to be code signed. Thankfully, SwiftyJSON already has all of this set properly. Mac OS X targets and tests are different altogether. They don't require code signing at all. Therefore, it should be disabled to allow users without a `Mac Developer` account to build SwiftyJSON on OS X and run the tests. All frameworks will get resigned anyways when embedded within the final app target.

This will make creating cross-platform libraries ontop of SwityJSON much easier for all those involved. You can find more information [here](https://github.com/Carthage/Carthage/issues/399) and [here](https://github.com/Carthage/Carthage/issues/281).