### PR TITLE
Fixed the buildable name in the OSX scheme

### DIFF
--- a/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON OSX.xcscheme
+++ b/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON OSX.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9C7DFC5A1A9102BD005AA3F7"
-               BuildableName = "SwiftyJSON OSX.framework"
+               BuildableName = "SwiftyJSON.framework"
                BlueprintName = "SwiftyJSON OSX"
                ReferencedContainer = "container:SwiftyJSON.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9C7DFC5A1A9102BD005AA3F7"
-            BuildableName = "SwiftyJSON OSX.framework"
+            BuildableName = "SwiftyJSON.framework"
             BlueprintName = "SwiftyJSON OSX"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
@@ -76,7 +76,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9C7DFC5A1A9102BD005AA3F7"
-            BuildableName = "SwiftyJSON OSX.framework"
+            BuildableName = "SwiftyJSON.framework"
             BlueprintName = "SwiftyJSON OSX"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>
@@ -94,7 +94,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9C7DFC5A1A9102BD005AA3F7"
-            BuildableName = "SwiftyJSON OSX.framework"
+            BuildableName = "SwiftyJSON.framework"
             BlueprintName = "SwiftyJSON OSX"
             ReferencedContainer = "container:SwiftyJSON.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
Just by opening the project, Xcode is modifying the buildable name in the OS X scheme. My guess is that when the OS X target was created along with the scheme, the scheme just didn't get updated properly when the `Product Name` of the target was updated. This small change fixes up the issue.