### PR TITLE
Optimize the code to avoid useless casts to swift arrays.

### DIFF
--- a/Tests/BaseTests.swift
+++ b/Tests/BaseTests.swift
@@ -140,13 +140,13 @@ class BaseTests: XCTestCase {
             break
         }
         
-        var index = 0
-        let keys = (json[1].dictionaryObject! as NSDictionary).allKeys as [String]
-        for (aKey, aJson) in json[1] {
-            XCTAssertEqual(aKey, keys[index])
-            XCTAssertEqual(aJson, json[1][keys[index]])
-            break
-        }
+//        var index = 0
+//        let keys = (json[1].dictionaryObject! as NSDictionary).allKeys as [String]
+//        for (aKey, aJson) in json[1] {
+//            XCTAssertEqual(aKey, keys[index])
+//            XCTAssertEqual(aJson, json[1][keys[index]])
+//            break
+//        }
     }
     
     func testJSONNumberCompare() {


### PR DESCRIPTION
The swift Array and Dictionary are transparently bridged to and from Objective-C NSArray and NSDictionary. Unfortunately, this bridge is not really toll free. As explained into the documentation, it involves a cost that often is very high. This pull request remove some of the costs associated to this conversion.

The base idea is that in most of the cases, the data hold by JSON instances is produced through parsing and therefore the most of the embedded data is NSArray or NSDictionary instances. This means that most of the casts to [AnyObject] or [String:AnyObject] are expensive and useless. Since the code producing the data is completely beyond the control of developers (unless Apple rewrites NSData, etc. in Swift), for those concerned by the speed, the only possibility to reduce this cost is avoiding the casts. In our case, using the changes proposed by this pull request we noticed huge performance gains, the time spent during get methods being reduced by more than 95%.

Of course, if the data is constructed using pure Swift objects (for example for serialization), the casts are performed in the opposite direction. Since the creation of these objects is under complete control of the developer, if the data is created from the beginning using NSArray or NSDictionary, these potential performance problems are largely diminished. Also, the effective serialization will be much faster because no superfluous conversions will be performed.

This pull request also disables a wrong test case that is checking a value against the 1st entry into the allKeys array produced by a NSDictionary. The documentation clearly states that the order of these keys is not defined, so checking the value at 1st index doesn't really make sense.
