### PR TITLE
Allow .number to parse number from string instead of just numberValue

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -668,6 +668,14 @@ extension JSON {
     public var number: NSNumber? {
         get {
             switch self.type {
+            case .String:
+                let scanner = NSScanner(string: self.object as! String)
+                if scanner.scanDouble(nil){
+                    if (scanner.atEnd) {
+                        return NSNumber(double:(self.object as! NSString).doubleValue)
+                    }
+                }
+                return nil
             case .Number, .Bool:
                 return self.object as? NSNumber
             default:
@@ -682,20 +690,7 @@ extension JSON {
     //Non-optional number
     public var numberValue: NSNumber {
         get {
-            switch self.type {
-            case .String:
-                let scanner = NSScanner(string: self.object as! String)
-                if scanner.scanDouble(nil){
-                    if (scanner.atEnd) {
-                        return NSNumber(double:(self.object as! NSString).doubleValue)
-                    }
-                }
-                return NSNumber(double: 0.0)
-            case .Number, .Bool:
-                return self.object as! NSNumber
-            default:
-                return NSNumber(double: 0.0)
-            }
+                return number ?? NSNumber(double: 0.0)
         }
         set {
             self.object = newValue.copy()


### PR DESCRIPTION
This lets .number try to return a value if the object is String. Before you could only use .numberValue to get a number from a string, but that would return 0 even if the value didn't exist