### PR TITLE
Add isTruthy computable property

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -1183,6 +1183,26 @@ public func >=(lhs: NSNumber, rhs: NSNumber) -> Bool {
     }
 }
 
+// MARK: - isTruthy
+extension JSON {
+    var isTruthy: Bool {
+        get {
+            switch self.type {
+            case .String:
+                return (self.object as! String) != ""
+            case .Number:
+                return (self.object as! NSNumber) != 0
+            case .Bool:
+                return (self.object as! Bool)
+            case .Array, .Dictionary:
+                return true
+            case .Null, .Unknown:
+                return false
+            }
+        }
+    }
+}
+
 //MARK:- Unavailable
 
 @availability(*, unavailable, renamed="JSON")


### PR DESCRIPTION
Found this property very useful when iterating through JSON objects, since there is no clean way to do this check otherwise. Figured it doesn't hurt to share, right?