### PR TITLE
replaces usage of stringByAddingPercentEscapesUsingEncoding

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -69,7 +69,9 @@ public struct JSON {
             let object: AnyObject = try NSJSONSerialization.JSONObjectWithData(data, options: opt)
             self.init(object)
         } catch let aError as NSError {
-            error.memory = aError
+            if error != nil {
+                error.memory = aError
+            }
             self.init(NSNull())
         }
     }

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -722,7 +722,7 @@ extension JSON {
         get {
             switch self.type {
             case .String:
-                if let encodedString_ = self.object.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding) {
+                if let encodedString_ = self.object.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) {
                     return NSURL(string: encodedString_)
                 } else {
                     return nil


### PR DESCRIPTION
replaces usage of stringByAddingPercentEscapesUsingEncoding (deprecated in iOS 9) with stringByAddingPercentEncodingWithAllowedCharacters