### PR TITLE
Update Deprecated Function

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -885,7 +885,7 @@ extension JSON {
         get {
             switch self.type {
             case .String:
-                if let encodedString_ = self.rawString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.alphanumericCharacterSet()) {
+                if let encodedString_ = self.rawString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) {
                     return NSURL(string: encodedString_)
                 } else {
                     return nil

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -885,7 +885,7 @@ extension JSON {
         get {
             switch self.type {
             case .String:
-                if let encodedString_ = self.rawString.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding) {
+                if let encodedString_ = self.rawString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.alphanumericCharacterSet()) {
                     return NSURL(string: encodedString_)
                 } else {
                     return nil


### PR DESCRIPTION
```
stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)
```
The above is deprecated as of Xcode 7/Swift 2.0

This is Apple's recommended replacement:
```
stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.alphanumericCharacterSet())
```