### PR TITLE
Fixes Compiler Warning for Xcode7B5

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -885,7 +885,7 @@ extension JSON {
         get {
             switch self.type {
             case .String:
-                if let encodedString_ = self.rawString.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding) {
+                if let encodedString_ = self.rawString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) {
                     return NSURL(string: encodedString_)
                 } else {
                     return nil


### PR DESCRIPTION
fixes compiler warning and uses NSCharacterSet.URLQueryAllowedCharacterSet() as allowedCharacters