### PR TITLE
Fix bad memory access with optional error pointer

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -69,7 +69,9 @@ public struct JSON {
             let object: AnyObject = try NSJSONSerialization.JSONObjectWithData(data, options: opt)
             self.init(object)
         } catch let aError as NSError {
-            error.memory = aError
+            if error != nil {
+                error.memory = aError
+            }
             self.init(NSNull())
         }
     }


### PR DESCRIPTION
Fixes a crash when a parse error occurs, but no NSErrorPointer has been passed into the JSON initialiser.