### PR TITLE
Parse string numbers as NSDecimalNumber instead of double

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -699,13 +699,11 @@ extension JSON {
         get {
             switch self.type {
             case .String:
-                let scanner = NSScanner(string: self.object as! String)
-                if scanner.scanDouble(nil){
-                    if (scanner.atEnd) {
-                        return NSNumber(double:(self.object as! NSString).doubleValue)
-                    }
+                let decimal = NSDecimalNumber(string: self.object as? String)
+                if decimal == NSDecimalNumber.notANumber() {  // indicates parse error
+                    return NSDecimalNumber.zero()
                 }
-                return NSNumber(double: 0.0)
+                return decimal
             case .Number, .Bool:
                 return self.object as! NSNumber
             default:

--- a/Tests/BaseTests.swift
+++ b/Tests/BaseTests.swift
@@ -167,7 +167,7 @@ class BaseTests: XCTestCase {
         XCTAssertLessThanOrEqual(JSON(-8763), JSON(-8763))
     }
 
-    func testNumberConverToString(){
+    func testNumberConvertToString(){
         XCTAssertEqual(JSON(true).stringValue, "true")
         XCTAssertEqual(JSON(999.9823).stringValue, "999.9823")
         XCTAssertEqual(JSON(true).number!.stringValue, "1")

--- a/Tests/NumberTests.swift
+++ b/Tests/NumberTests.swift
@@ -31,14 +31,23 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(json.numberValue, 9876543210.123456789)
         XCTAssertEqual(json.stringValue, "9876543210.123457")
         
+        json.string = "1000000000000000000000000000.1"
+        XCTAssertNil(json.number)
+        XCTAssertEqual(json.numberValue.description, "1000000000000000000000000000.1")
+
+        json.string = "1e+27"
+        XCTAssertEqual(json.numberValue.description, "1000000000000000000000000000")
+        
         //setter
         json.number = NSNumber(double: 123456789.0987654321)
         XCTAssertEqual(json.number!, 123456789.0987654321)
         XCTAssertEqual(json.numberValue, 123456789.0987654321)
+        
         json.number = nil
         XCTAssertEqual(json.numberValue, 0)
         XCTAssertEqual(json.object as! NSNull, NSNull())
         XCTAssertTrue(json.number == nil)
+        
         json.numberValue = 2.9876
         XCTAssertEqual(json.number!, 2.9876)
     }


### PR DESCRIPTION
Code should never use floating point numbers to represent money, or any other value where exact decimal rounding is important. (See [here](http://spin.atomicobject.com/2014/08/14/currency-rounding-errors/) and [here](http://stackoverflow.com/questions/3730019/why-not-use-double-or-float-to-represent-currency) for the reasons why.)

Because of this, developers often use strings to represent currency in JSON. However, SwiftyJSON’s `numberValue` applied to a string element parses the string as a double, thus defeating this technique. Because `numberValue` returns `NSNumber` and not `Double`, it’s not at all obvious to someone using SwiftyJSON that this floating point conversion happens — a potential source of dangerous bugs!

Cocoa provides `NSDecimalNumber` for exactly this situation, and SwiftyJSON should return it when parsing a string as a number. This patch does that.

Two notes:

- The `number` property (as opposed to `numberValue`) does not even attempt to parse strings. It might make more sense for it to attempt the parsing, and return nil if the parsing fails. While potentially surprising, I have left the existing behavior in place.
- `NSDecimalNumber` returns `NaN` instead of `0` if a string does not parse. This behavior arguably makes more sense. However, I’ve preserved SwiftyJSON’s existing behavior for `numberValue`.