### PR TITLE
Fixes for issues found in Xcode 7 GM and error handling for rawData()

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -1265,7 +1265,7 @@ private let falseObjCType = String.fromCString(falseNumber.objCType)
 
 // MARK: - NSNumber: Comparable
 
-extension NSNumber: Swift.Comparable {
+extension NSNumber {
     var isBool:Bool {
         get {
             let objCType = String.fromCString(self.objCType)

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -32,6 +32,7 @@ public let ErrorUnsupportedType: Int! = 999
 public let ErrorIndexOutOfBounds: Int! = 900
 public let ErrorWrongType: Int! = 901
 public let ErrorNotExist: Int! = 500
+public let ErrorInvalidJSON: Int! = 490
 
 // MARK: - JSON Type
 
@@ -610,6 +611,10 @@ extension JSON: Swift.RawRepresentable {
     }
     
     public func rawData(options opt: NSJSONWritingOptions = NSJSONWritingOptions(rawValue: 0)) throws -> NSData {
+        guard NSJSONSerialization.isValidJSONObject(self.object) else {
+            throw NSError(domain: ErrorDomain, code: ErrorInvalidJSON, userInfo: [NSLocalizedDescriptionKey: "JSON is invalid"])
+        }
+        
         return try NSJSONSerialization.dataWithJSONObject(self.object, options: opt)
     }
     

--- a/Tests/BaseTests.swift
+++ b/Tests/BaseTests.swift
@@ -254,8 +254,8 @@ class BaseTests: XCTestCase {
     func testNumberCompare(){
         XCTAssertEqual(NSNumber(double: 888332), NSNumber(int:888332))
         XCTAssertNotEqual(NSNumber(double: 888332.1), NSNumber(int:888332))
-        XCTAssertLessThan(NSNumber(int: 888332), NSNumber(double:888332.1))
-        XCTAssertGreaterThan(NSNumber(double: 888332.1), NSNumber(int:888332))
+        XCTAssertLessThan(NSNumber(int: 888332).doubleValue, NSNumber(double:888332.1).doubleValue)
+        XCTAssertGreaterThan(NSNumber(double: 888332.1).doubleValue, NSNumber(int:888332).doubleValue)
         XCTAssertFalse(NSNumber(double: 1) == NSNumber(bool:true))
         XCTAssertFalse(NSNumber(int: 0) == NSNumber(bool:false))
         XCTAssertEqual(NSNumber(bool: false), NSNumber(bool:false))

--- a/Tests/RawTests.swift
+++ b/Tests/RawTests.swift
@@ -42,8 +42,6 @@ class RawTests: XCTestCase {
             try json.rawData()
         } catch let error as NSError {
             XCTAssertEqual(error.code, ErrorInvalidJSON)
-        } catch {
-            XCTFail()
         }
     }
     

--- a/Tests/RawTests.swift
+++ b/Tests/RawTests.swift
@@ -25,6 +25,28 @@ import SwiftyJSON
 
 class RawTests: XCTestCase {
 
+    func testRawData() {
+        let json: JSON = ["somekey" : "some string value"]
+        let expectedRawData = "{\"somekey\":\"some string value\"}".dataUsingEncoding(NSUTF8StringEncoding)
+        do {
+            let data: NSData = try json.rawData()
+            XCTAssertEqual(expectedRawData, data)
+        } catch _ {
+            XCTFail()
+        }
+    }
+    
+    func testInvalidJSONForRawData() {
+        let json: JSON = "...<nonsense>xyz</nonsense>"
+        do {
+            try json.rawData()
+        } catch let error as NSError {
+            XCTAssertEqual(error.code, ErrorInvalidJSON)
+        } catch {
+            XCTFail()
+        }
+    }
+    
     func testArray() {
         let json:JSON = [1, "2", 3.12, NSNull(), true, ["name": "Jack"]]
         let data: NSData?


### PR DESCRIPTION
The set of commits are as follows:

1. This accommodates a Foundation change in XCode 7 GM (`NSNumber` now conforms to `Swift.Comparable` by default)
2. XCTest > and < assertions care more about types, so this fixes the test in BaseTests that broke
3. The third commit fixes the way exceptions are handled in `rawData`. `testInvalidJSONForRawData` demonstrates the use case. Prior to the change, this test will fail, but it is never caught as `NSJSONSerialization` throws a different exception. Apple recommends validating the input with `isValidJSONObject` so I've added this to `rawData()` within a Swift 2.0 `guard`