### PR TITLE
Numeric 0 Issues

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -786,6 +786,10 @@ extension JSON {
             switch self.type {
             case .String:
                 return self.object as? String
+            case .Number:
+                return self.object.stringValue
+            case .Bool:
+                return (self.object as! Bool).description
             default:
                 return nil
             }

--- a/Tests/NumberTests.swift
+++ b/Tests/NumberTests.swift
@@ -49,11 +49,14 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(json.boolValue, true)
         XCTAssertEqual(json.numberValue, true as NSNumber)
         XCTAssertEqual(json.stringValue, "true")
+        XCTAssertEqual(json.string, "true")
         
         json.bool = false
         XCTAssertEqual(json.bool!, false)
         XCTAssertEqual(json.boolValue, false)
         XCTAssertEqual(json.numberValue, false as NSNumber)
+        XCTAssertEqual(json.stringValue, "false")
+        XCTAssertEqual(json.string, "false")
         
         json.bool = nil
         XCTAssertTrue(json.bool == nil)
@@ -132,6 +135,21 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(json.intValue, 98765421)
         XCTAssertEqual(json.numberValue, NSNumber(integer: 98765421))
     }
+    
+    func testZero() {
+        var json = JSON(0)
+        XCTAssertEqual(json.int!, 0)
+        XCTAssertEqual(json.intValue, 0)
+        XCTAssertEqual(json.numberValue, NSNumber(integer: 0))
+        XCTAssertEqual(json.stringValue, "0")
+        XCTAssertEqual(json.string, "0")
+        
+        json.intValue = 0
+        XCTAssertEqual(json.int!, 0)
+        XCTAssertEqual(json.intValue, 0)
+        XCTAssertEqual(json.numberValue, NSNumber(integer: 0))
+    }
+
     
     func testUInt() {
         var json = JSON(123456789)


### PR DESCRIPTION
I had an issue where a numeric 0 was being returned in the JSON from my server.  When I attempted to get an optional value out of the JSON with something like the following where json[0]["identifier"] = 0, I was getting a nil value for the optional.

```
guard let identifier = json[0]["identifier"].string else {
    return
}
```

When using .stringValue to get a non-optional, the correct string of "0" was being returned.

This PR addresses this for both Bool values and Numeric values.

