### PR TITLE
Add support for tvOS

### DIFF
--- a/SwiftyJSON.podspec
+++ b/SwiftyJSON.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.9"
   s.ios.deployment_target = "8.0"
   s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
   s.source   = { :git => "https://github.com/SwiftyJSON/SwiftyJSON.git", :tag => "2.3.0"}
   s.source_files = "Source/*.swift"
 end


### PR DESCRIPTION
This patch adds support to the pod to be used on a tvOS app project.

I have a development kit and have verified it working on my AppleTV app.