### PR TITLE
Sets UIRequiredDeviceCapabilities for tvOS target

### DIFF
--- a/Source/Info-tvOS.plist
+++ b/Source/Info-tvOS.plist
@@ -22,5 +22,9 @@
 	<string>${CURRENT_PROJECT_VERSION}</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
arm64 must be set in UIRequiredDeviceCapabilities for tvOS targets when uploading to iTunes Connect.