### PR TITLE
Correct JSON's type specification URL

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -39,7 +39,7 @@ public let ErrorInvalidJSON: Int! = 490
 /**
 JSON's type definitions.
 
-See http://tools.ietf.org/html/rfc7231#section-4.3
+See http://www.json.org
 */
 public enum Type :Int{
 


### PR DESCRIPTION
Wrong JSON's type specification URL, it should be http://www.json.org.