### PR TITLE
Changed from .empty to .isEmpty

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -235,7 +235,7 @@ extension JSON : Swift.CollectionType, Swift.SequenceType, Swift.Indexable {
         }
     }
 
-    /// If `type` is `.Array` or `.Dictionary`, return `array.empty` or `dictonary.empty` otherwise return `true`.
+    /// If `type` is `.Array` or `.Dictionary`, return `array.isEmpty` or `dictonary.isEmpty` otherwise return `true`.
     public var isEmpty: Bool {
         get {
             switch self.type {


### PR DESCRIPTION
The comment had array.empty which but it was implemented by array.isEmpty and similar for dictionary. Although the intent is clear, the comment suggested it was the code portion and it was mismatching. Thus, i think its necessary.