### PR TITLE
String keypath support 

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -517,14 +517,33 @@ extension JSON {
     */
     public subscript(path: [JSONSubscriptType]) -> JSON {
         get {
-            return path.reduce(self) { $0[sub: $1] }
+            return path.reduce(self) { json, type in
+                var value: JSON?
+                doKeypath(type,
+                    subscriptClosure: {
+                        value = json[sub: type]
+                    },
+                    keypathClosure: { components in
+                        value = json[components]
+                    }
+                )
+                return value!
+            }
         }
         set {
             switch path.count {
             case 0:
                 return
             case 1:
-                self[sub:path[0]].object = newValue.object
+                let path = path[0]
+                doKeypath(path,
+                    subscriptClosure: {
+                        self[sub: path].object = newValue.object
+                    },
+                    keypathClosure: { components in
+                        self[components].object = newValue.object
+                    }
+                )
             default:
                 var aPath = path; aPath.removeAtIndex(0)
                 var nextJSON = self[sub: path[0]]
@@ -1206,6 +1225,27 @@ extension JSON {
 
 //MARK: - Comparable
 extension JSON : Swift.Comparable {}
+
+//MARK: - Keypath
+extension JSON {
+    private func doKeypath(subscriptType: JSONSubscriptType, subscriptClosure: () -> Void, keypathClosure: (components: [JSONSubscriptType]) -> Void) {
+        switch subscriptType.jsonKey {
+        case .Index(_):
+            subscriptClosure()
+        case .Key(let path):
+            let components = path.componentsSeparatedByString(".")
+            if components.count > 1 {
+                let components: [JSONSubscriptType] = components.map { key in
+                    let index = Int(key)
+                    return index != nil ? index! : key
+                }
+                keypathClosure(components: components)
+            } else {
+                subscriptClosure()
+            }
+        }
+    }
+}
 
 public func ==(lhs: JSON, rhs: JSON) -> Bool {
 

--- a/Tests/SubscriptTests.swift
+++ b/Tests/SubscriptTests.swift
@@ -262,4 +262,12 @@ class SubscriptTests: XCTestCase {
         XCTAssertEqual(json["user","info","email"], "tom@qq.com")
         XCTAssertEqual(json["user","feeds"], [77323,2313,4545,323])
     }
+    
+    func testKeypath() {
+        var json:JSON = ["user":["id":987654, "info":["name":"jack","email":"jack@gmail.com"], "feeds":[98833,23443,213239,23232]]]
+        XCTAssertEqual(json["user.id"], 987654)
+        XCTAssertEqual(json["user.feeds.1"], 23443)
+        json["user.feeds.2"] = 666
+        XCTAssertEqual(json["user","feeds",2], 666)
+    }
 }


### PR DESCRIPTION
JSON objects can be indexed by a key path like "items.0.isActive"