### PR TITLE
Rename isExists to exists. Fixes #448

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -904,7 +904,7 @@ extension JSON {
             self.object = NSNull()
         }
     }
-    public func isExists() -> Bool{
+    public func exists() -> Bool{
         if let errorValue = error where errorValue.code == ErrorNotExist{
             return false
         }

--- a/Tests/BaseTests.swift
+++ b/Tests/BaseTests.swift
@@ -229,8 +229,8 @@ class BaseTests: XCTestCase {
     func testExistance() {
         let dictionary = ["number":1111]
         let json = JSON(dictionary)
-        XCTAssertFalse(json["unspecifiedValue"].isExists())
-        XCTAssertTrue(json["number"].isExists())
+        XCTAssertFalse(json["unspecifiedValue"].exists())
+        XCTAssertTrue(json["number"].exists())
     }
     
     func testErrorHandle() {


### PR DESCRIPTION
`isExists()` isn't the correct way to phrase that statement and makes the code harder to read. Simply using `exists()` makes it easer to read and grammatically correct.

```swift
json["user"].exists()
```