### PR TITLE
correct README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ if let string = json.rawString() {
     //Do something you want
 }
 ```
-####Existance
+####Existence
 ```swift
 //shows you whether value specified in JSON or not
 if json["name"].isExists()


### PR DESCRIPTION
This pull request correctly changes the spelling of "Existance" to "Existence"

Additional reference: http://www.yourdictionary.com/existance