### PR TITLE
added rawStringFlat and rawStringPretty

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -665,6 +665,14 @@ extension JSON: Swift.RawRepresentable {
             return nil
         }
     }
+    
+    public func rawStringPretty() -> String? {
+        return rawString(options: .PrettyPrinted)
+    }
+    
+    public func rawStringFlat() -> String? {
+        return rawString(options: [])
+    }
 }
 
 // MARK: - Printable, DebugPrintable

--- a/SwiftyJSON.podspec
+++ b/SwiftyJSON.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
-  s.source   = { :git => "https://github.com/SwiftyJSON/SwiftyJSON.git", :tag => s.version }
+  s.source   = { :git => "https://github.com/SwiftyJSON/SwiftyJSON.git", :branch => master }
   s.source_files = "Source/*.swift"
 end

--- a/Tests/RawTests.swift
+++ b/Tests/RawTests.swift
@@ -96,4 +96,28 @@ class RawTests: XCTestCase {
         print(json.rawString())
         XCTAssertTrue(json.rawString() == "null")
     }
+    
+    func testPrettyAndFlat() {
+        let json:JSON = ["number":1234, "name":"Jack", "list":[1,2,3,4], "bool":false]
+        let flatString = json.rawStringFlat()
+        let prettyString = json.rawStringPretty()
+        XCTAssertNotNil(flatString)
+        XCTAssertNotNil(prettyString)
+        
+        print(flatString!)
+        XCTAssertEqual("{\"number\":1234,\"bool\":false,\"list\":[1,2,3,4],\"name\":\"Jack\"}", flatString)
+        
+        print(prettyString!)
+        XCTAssertEqual("{\n" +
+            "  \"number\" : 1234,\n" +
+            "  \"bool\" : false,\n" +
+            "  \"list\" : [\n" +
+            "    1,\n" +
+            "    2,\n" +
+            "    3,\n" +
+            "    4\n" +
+            "  ],\n" +
+            "  \"name\" : \"Jack\"\n" +
+            "}", prettyString)
+    }
 }


### PR DESCRIPTION
Hi all,

I think that `rawString` should return a flat rappresentation of a json object but this is not true in the current implementation.
I don't want to break stuff so I decided to make the json format explicit by creating two new methods, `rawStringFlat` and `rawStringPretty` so it's much obvious which is the string format returned.

It also helps keep the code cleaner.
