### PR TITLE
No need to specify git repo when adding via CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ platform :ios, '8.0'
 use_frameworks!
 
 target 'MyApp' do
-	pod 'SwiftyJSON', :git => 'https://github.com/SwiftyJSON/SwiftyJSON.git'
+    pod 'SwiftyJSON'
 end
 ```
 Note that this requires CocoaPods version 36, and your iOS deployment target to be at least 8.0:


### PR DESCRIPTION
You usually need to specify git repo url if you want to use a fork or if you want to reference to a specific commit. Im most cases just name of the pod is enough. Its url is in its spec: https://github.com/CocoaPods/Specs/blob/master/Specs/SwiftyJSON/2.3.2/SwiftyJSON.podspec.json#L21