### PR TITLE
Allow exists method to handle out of bounds and wrong type errors

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -779,8 +779,10 @@ extension JSON {
         }
     }
     public func exists() -> Bool{
-        if let errorValue = error , errorValue.code == ErrorNotExist{
-            return false
+        if let errorValue = error, errorValue.code == ErrorNotExist ||
+            errorValue.code == ErrorIndexOutOfBounds ||
+            errorValue.code == ErrorWrongType {
+                return false
         }
         return true
     }

--- a/Tests/BaseTests.swift
+++ b/Tests/BaseTests.swift
@@ -214,7 +214,14 @@ class BaseTests: XCTestCase {
         let dictionary = ["number":1111]
         let json = JSON(dictionary)
         XCTAssertFalse(json["unspecifiedValue"].exists())
+        XCTAssertFalse(json[0].exists())
         XCTAssertTrue(json["number"].exists())
+
+        let array = [["number":1111]]
+        let jsonForArray = JSON(array)
+        XCTAssertTrue(jsonForArray[0].exists())
+        XCTAssertFalse(jsonForArray[1].exists())
+        XCTAssertFalse(jsonForArray["someValue"].exists())
     }
     
     func testErrorHandle() {


### PR DESCRIPTION
Allow the `exists` method to handle out of bounds and wrong type errors by checking for `errorValue.code == ErrorIndexOutOfBounds` and `errorValue.code == ErrorWrongType`.

For example, when we have `let jsonForArray = JSON([["number":1111]])` we would expect `jsonForArray[1].exists()` and `jsonForArray["someValue"].exists()` to return false.

I think the change here might fix the issue related to https://github.com/SwiftyJSON/SwiftyJSON/issues/498


