### PR TITLE
updated "Swift Package Manager" installation manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ let package = Package(
     name: "YOUR_PROJECT_NAME",
     targets: [],
     dependencies: [
-        .Package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", versions: "2.3.3" ..< Version.max)
+        .Package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", versions: Version(1,0,0)..<Version(2, .max, .max)),
     ]
 )
 ```


### PR DESCRIPTION
seems to be, that the Swift Package Manager has updated the kind of defining Versions.
But on "swift build -v" we have still a issue:

/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc --driver-mode=swift -I /Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib/swift/pm -L /Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib/swift/pm -lPackageDescription -target x86_64-apple-macosx10.10 /Users/jan/Development/iOS/Global\ Nights/Package.swift -fileno 4
/Users/jan/Development/iOS/Global Nights/Package.swift:15:17: error: incorrect argument labels in call (have 'url:tag:versions:', expected 'url:majorVersion:minor:')
        .Package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", tag: "2.3.3", versions: Version(1,0,0)..<Version(2,3,3)),
                ^                                                     ~~~           ~~~~~~~~
                                                                      majorVersion  minor
error: exit(1): /Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc --driver-mode=swift -I /Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib/swift/pm -L /Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib/swift/pm -lPackageDescription -target x86_64-apple-macosx10.10 /Users/jan/Development/iOS/Global\ Nights/Package.swift -fileno 4