### PR TITLE
Fixing some syntax updates

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -736,8 +736,8 @@ extension JSON {
             switch self.type {
             case .string:
                 let decimal = NSDecimalNumber(string: self.object as? String)
-                if decimal == NSDecimalNumber.notANumber() {  // indicates parse error
-                    return NSDecimalNumber.zero()
+                if decimal == NSDecimalNumber.notA {  // indicates parse error
+                    return NSDecimalNumber.zero
                 }
                 return decimal
             case .number, .bool:


### PR DESCRIPTION
- 'notANumber' has been renamed to 'notA'
- NSDecimalNumber.zero() : "Cannot call value of non-function type 'NSDecimalNumber'"