### PR TITLE
- Syntax updated.

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -736,8 +736,8 @@ extension JSON {
             switch self.type {
             case .string:
                 let decimal = NSDecimalNumber(string: self.object as? String)
-                if decimal == NSDecimalNumber.notANumber() {  // indicates parse error
-                    return NSDecimalNumber.zero()
+                if decimal == NSDecimalNumber.notA {  // indicates parse error
+                    return NSDecimalNumber.zero
                 }
                 return decimal
             case .number, .bool:


### PR DESCRIPTION
Apple updated some syntax in Swift3. 
`NSDecimalNumber.notANumber()` changed to `NSDecimalNumber.notA`
`NSDecimalNumber.zero()` changed to `NSDecimalNumber.zero`