### PR TITLE
fixed equality checking for JSONIndex

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -206,6 +206,8 @@ public func ==(lhs: JSONIndex, rhs: JSONIndex) -> Bool {
         return left == right
     case (.dictionary(let left), .dictionary(let right)):
         return left == right
+    case (.null, .null):
+        return true
     default:
         return false
     }


### PR DESCRIPTION
This PR includes a fix that I think is required to correctly check two JSONIndex instances whose internal types are .null for equality. Without this fix, two .null JSONIndexes are considered not equal, which leads to problems when iterating over JSON objects. 

Lets say we have the following code:

```swift
for (index, subJson) in json["key_that_does_not_exists"] {
   // other code
}
```

This leads to an infinite loop because the return values of startIndex, endIndex and index(after:) in the JSON: Collection extension all return .null Indexes which are considered not equal.