### PR TITLE
Performance enhancements when accessing dictionary

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -598,11 +598,11 @@ extension JSON: Swift.FloatLiteralConvertible {
 extension JSON: Swift.DictionaryLiteralConvertible {
 
     public init(dictionaryLiteral elements: (String, AnyObject)...) {
-        self.init(elements.reduce([String : AnyObject](minimumCapacity: elements.count)){(dictionary: [String : AnyObject], element:(String, AnyObject)) -> [String : AnyObject] in
-            var d = dictionary
-            d[element.0] = element.1
-            return d
-            })
+        var d = [String:AnyObject](minimumCapacity: elements.count)
+        for (key,value) in elements {
+            d[key] = value
+        }
+        self.init(d)
     }
 }
 
@@ -733,11 +733,11 @@ extension JSON {
     //Optional [String : JSON]
     public var dictionary: [String : JSON]? {
         if self.type == .Dictionary {
-            return self.rawDictionary.reduce([String : JSON](minimumCapacity: count)) { (dictionary: [String : JSON], element: (String, AnyObject)) -> [String : JSON] in
-                var d = dictionary
-                d[element.0] = JSON(element.1)
-                return d
+            var d = [String:JSON](minimumCapacity: self.rawDictionary.count)
+            for (key,value) in self.rawDictionary {
+                d[key] = JSON(value)
             }
+            return d
         } else {
             return nil
         }

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -96,5 +96,23 @@ class PerformanceTests: XCTestCase {
             }
         }
     }
+    
+    func testLargeDictionaryMethodPerformance() {
+        var data: [String: JSON] = [:]
+        (0...100000).forEach { n in
+            data["\(n)"] = JSON([
+                "name": "item\(n)",
+                "id": n
+                ])
+        }
+        let json = JSON(data)
+
+        self.measureBlock() {
+            autoreleasepool{
+                let dictionary = json.dictionary
+                XCTAssertTrue(dictionary?.count > 0)
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
We ran into some performance issues when using JSON documents with a large number of records.

The first commit adds a test case which demonstrates the issue. On my laptop, this test takes 23 minutes to run.

The second commit fixes the performance issue bringing the execution time to 3 seconds.

The main issue is that, in Swift, each iteration in the reduce treats the dictionary as non-mutable and copies it into a new instance each time it adds a new element. This results a lot of object creation/releasing churn with O(n*n) performance. The fix replaces this with an implementation with O(n) complexity.