### PR TITLE
Represent JSON as string even if Swift can't do it

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,17 @@ let auth: JSON = [
 ]
 ```
 
+## String representation
+There are two options available:
+- use the default Swift one
+- use a custom one that will handle optionals well and represent `nil` as `"null"`:
+```swift
+let data = ["1":2, "2":"two", "3": nil] as [String: Any?]
+let json = JSON(dict)
+let representation = json.rawString(options: [.castNilToNSNull: true])
+// representation is "{\"1\":2,\"2\":\"two\",\"3\":null}", which represents {"1":2,"2":"two","3":null}
+```
+
 ## Work with Alamofire
 
 SwiftyJSON nicely wraps the result of the Alamofire JSON response handler:

--- a/Tests/SwiftyJSONTests/PrintableTests.swift
+++ b/Tests/SwiftyJSONTests/PrintableTests.swift
@@ -62,6 +62,26 @@ class PrintableTests: XCTestCase {
         XCTAssertTrue(json.description.lengthOfBytes(using: String.Encoding.utf8) > 0)
         XCTAssertTrue(json.debugDescription.lengthOfBytes(using: String.Encoding.utf8) > 0)
     }
+
+    func testArrayWithStrings() {
+        let array = ["\"123\""]
+        let json = JSON(array)
+        var description = json.description.replacingOccurrences(of: "\n", with: "")
+        description = description.replacingOccurrences(of: " ", with: "")
+        XCTAssertEqual(description, "[\"\\\"123\\\"\"]")
+        XCTAssertTrue(json.description.lengthOfBytes(using: String.Encoding.utf8) > 0)
+        XCTAssertTrue(json.debugDescription.lengthOfBytes(using: String.Encoding.utf8) > 0)
+    }
+
+    func testArrayWithOptionals() {
+        let array = [1,2,"4",5,"6",nil] as [Any?]
+        let json = JSON(array)
+        var description = json.description.replacingOccurrences(of: "\n", with: "")
+        description = description.replacingOccurrences(of: " ", with: "")
+        XCTAssertEqual(description, "[1,2,\"4\",5,\"6\",null]")
+        XCTAssertTrue(json.description.lengthOfBytes(using: String.Encoding.utf8) > 0)
+        XCTAssertTrue(json.debugDescription.lengthOfBytes(using: String.Encoding.utf8) > 0)
+    }
     
     func testDictionary() {
         let json:JSON = ["1":2,"2":"two", "3":3]
@@ -71,5 +91,27 @@ class PrintableTests: XCTestCase {
         XCTAssertTrue(debugDescription.range(of: "\"1\":2", options: String.CompareOptions.caseInsensitive) != nil)
         XCTAssertTrue(debugDescription.range(of: "\"2\":\"two\"", options: String.CompareOptions.caseInsensitive) != nil)
         XCTAssertTrue(debugDescription.range(of: "\"3\":3", options: String.CompareOptions.caseInsensitive) != nil)
+    }
+
+    func testDictionaryWithStrings() {
+        let dict = ["foo":"{\"bar\":123}"] as [String : Any]
+        let json = JSON(dict)
+        var debugDescription = json.debugDescription.replacingOccurrences(of: "\n", with: "")
+        debugDescription = debugDescription.replacingOccurrences(of: " ", with: "")
+        XCTAssertTrue(json.description.lengthOfBytes(using: String.Encoding.utf8) > 0)
+        let exceptedResult = "{\"foo\":\"{\\\"bar\\\":123}\"}"
+        XCTAssertEqual(debugDescription, exceptedResult)
+    }
+
+    func testDictionaryWithOptionals() {
+        let dict = ["1":2, "2":"two", "3": nil] as [String: Any?]
+        let json = JSON(dict)
+        var debugDescription = json.debugDescription.replacingOccurrences(of: "\n", with: "")
+        debugDescription = debugDescription.replacingOccurrences(of: " ", with: "")
+        print("debugDescription", debugDescription)
+        XCTAssertTrue(json.description.lengthOfBytes(using: String.Encoding.utf8) > 0)
+        XCTAssertTrue(debugDescription.range(of: "\"1\":2", options: NSString.CompareOptions.caseInsensitive) != nil)
+        XCTAssertTrue(debugDescription.range(of: "\"2\":\"two\"", options: NSString.CompareOptions.caseInsensitive) != nil)
+        XCTAssertTrue(debugDescription.range(of: "\"3\":null", options: NSString.CompareOptions.caseInsensitive) != nil)
     }
 }

--- a/Tests/SwiftyJSONTests/PrintableTests.swift
+++ b/Tests/SwiftyJSONTests/PrintableTests.swift
@@ -76,7 +76,11 @@ class PrintableTests: XCTestCase {
     func testArrayWithOptionals() {
         let array = [1,2,"4",5,"6",nil] as [Any?]
         let json = JSON(array)
-        var description = json.description.replacingOccurrences(of: "\n", with: "")
+		guard var description = json.rawString(options: [.castNilToNSNull: true]) else {
+			XCTFail("could not represent array")
+			return
+		}
+		description = description.replacingOccurrences(of: "\n", with: "")
         description = description.replacingOccurrences(of: " ", with: "")
         XCTAssertEqual(description, "[1,2,\"4\",5,\"6\",null]")
         XCTAssertTrue(json.description.lengthOfBytes(using: String.Encoding.utf8) > 0)
@@ -106,12 +110,15 @@ class PrintableTests: XCTestCase {
     func testDictionaryWithOptionals() {
         let dict = ["1":2, "2":"two", "3": nil] as [String: Any?]
         let json = JSON(dict)
-        var debugDescription = json.debugDescription.replacingOccurrences(of: "\n", with: "")
-        debugDescription = debugDescription.replacingOccurrences(of: " ", with: "")
-        print("debugDescription", debugDescription)
+		guard var description = json.rawString(options: [.castNilToNSNull: true]) else {
+			XCTFail("could not represent dictionary")
+			return
+		}
+		description = description.replacingOccurrences(of: "\n", with: "")
+        description = description.replacingOccurrences(of: " ", with: "")
         XCTAssertTrue(json.description.lengthOfBytes(using: String.Encoding.utf8) > 0)
-        XCTAssertTrue(debugDescription.range(of: "\"1\":2", options: NSString.CompareOptions.caseInsensitive) != nil)
-        XCTAssertTrue(debugDescription.range(of: "\"2\":\"two\"", options: NSString.CompareOptions.caseInsensitive) != nil)
-        XCTAssertTrue(debugDescription.range(of: "\"3\":null", options: NSString.CompareOptions.caseInsensitive) != nil)
+        XCTAssertTrue(description.range(of: "\"1\":2", options: NSString.CompareOptions.caseInsensitive) != nil)
+        XCTAssertTrue(description.range(of: "\"2\":\"two\"", options: NSString.CompareOptions.caseInsensitive) != nil)
+        XCTAssertTrue(description.range(of: "\"3\":null", options: NSString.CompareOptions.caseInsensitive) != nil)
     }
 }


### PR DESCRIPTION
Swift cannot represent dictionaries with `nil` values as json (http://stackoverflow.com/questions/13908094/how-to-include-null-value-in-the-json-via-nsjsonserialization) and the current SwiftyJSON string representation that relies on the default swift JSON string representation will fail as way.

Here I created a custom string representation that doesn't doesn't rely on the built in one, and can handle things with nil or values. I also added a few tests.
