### PR TITLE
Add debugging information (Path)

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -188,10 +188,13 @@ public struct JSON {
     /// Error in JSON
     public var error: NSError? { get { return self._error } }
 
+    public var currentPath: String = "root"
+    
     /// The static null json
     @available(*, unavailable, renamed="null")
     public static var nullJSON: JSON { get { return null } }
     public static var null: JSON { get { return JSON(NSNull()) } }
+    
 }
 
 // MARK: - CollectionType, SequenceType, Indexable
@@ -450,7 +453,9 @@ extension JSON {
                 r._error = self._error ?? NSError(domain: ErrorDomain, code: ErrorWrongType, userInfo: [NSLocalizedDescriptionKey: "Array[\(index)] failure, It is not an array"])
                 return r
             } else if index >= 0 && index < self.rawArray.count {
-                return JSON(self.rawArray[index])
+                var json = JSON(self.rawArray[index])
+                json.currentPath = self.currentPath + "[\(index)]"
+                return json
             } else {
                 var r = JSON.null
                 r._error = NSError(domain: ErrorDomain, code:ErrorIndexOutOfBounds , userInfo: [NSLocalizedDescriptionKey: "Array[\(index)] is out of bounds"])
@@ -473,6 +478,7 @@ extension JSON {
             if self.type == .Dictionary {
                 if let o = self.rawDictionary[key] {
                     r = JSON(o)
+                    r.currentPath = self.currentPath + "[\"\(key)\"]"
                 } else {
                     r._error = NSError(domain: ErrorDomain, code: ErrorNotExist, userInfo: [NSLocalizedDescriptionKey: "Dictionary[\"\(key)\"] does not exist"])
                 }


### PR DESCRIPTION
### Problem

A `SwiftyJSON.JSON` created with `SwiftyJSON.JSON[key]` does not know itself's path.
If it does, it would be useful debugging information.
For example, debugging an error when accessing with a non existing key: `SwiftyJSON.JSON[key][nonExistKey]`
### Solution

A. Completely wrap SwiftyJSON.JSON
B. Add a property to SwiftyJSON.JSON to keep track of itself's path

I implemented B, and it could be used like this:

```
let childJSON = JSON["foo"][12]["bar"]
```

What is the path of `childJSON`? What keys were used?

```
print(childJSON.currentPath)
-> "root["foo"][12]["bar"]"
```

I'm looking for a better name for the property `currentPath`. Maybe `pathToSelf`?
