### PR TITLE
Update NSErrorPointer usage in initializer.

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -65,13 +65,13 @@ public struct JSON {
      
      - returns: The created JSON
      */
-    public init(data:Data, options opt: JSONSerialization.ReadingOptions = .allowFragments, error: NSErrorPointer? = nil) {
+    public init(data:Data, options opt: JSONSerialization.ReadingOptions = .allowFragments, error: NSErrorPointer = nil) {
         do {
             let object: Any = try JSONSerialization.jsonObject(with: data, options: opt)
             self.init(object)
         } catch let aError as NSError {
             if error != nil {
-                error??.pointee = aError
+                error?.pointee = aError
             }
             self.init(NSNull())
         }


### PR DESCRIPTION
Referencing #633 , this PR updates the initialiser use of NSErrorPointer.

In Swift 3 `NSErrorPointer` is defined as:

`public typealias NSErrorPointer = AutoreleasingUnsafeMutablePointer<NSError?>?`

hence the optionality of the error parameter can be removed.