### PR TITLE
Swift 3: Move from NSURL to URL #649

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -790,12 +790,13 @@ extension JSON {
 extension JSON {
     
     //Optional URL
-    public var URL: NSURL? {
+    public var URL: URL? {
         get {
             switch self.type {
             case .string:
                 if let encodedString_ = self.rawString.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) {
-                    return NSURL(string: encodedString_)
+                    // We have to use `Foundation.URL` otherwise it conflicts with the variable name.
+                    return Foundation.URL(string: encodedString_)
                 } else {
                     return nil
                 }

--- a/Tests/BaseTests.swift
+++ b/Tests/BaseTests.swift
@@ -122,13 +122,13 @@ class BaseTests: XCTestCase {
         let user_name = user["name"].string
         let user_profile_image_url = user["profile_image_url"].URL
         XCTAssert(user_name == "OAuth Dancer")
-        XCTAssert(user_profile_image_url == NSURL(string: "http://a0.twimg.com/profile_images/730275945/oauth-dancer_normal.jpg"))
+        XCTAssert(user_profile_image_url == URL(string: "http://a0.twimg.com/profile_images/730275945/oauth-dancer_normal.jpg"))
 
         let user_dictionary = json[0]["user"].dictionary
         let user_dictionary_name = user_dictionary?["name"]?.string
         let user_dictionary_name_profile_image_url = user_dictionary?["profile_image_url"]?.URL
         XCTAssert(user_dictionary_name == "OAuth Dancer")
-        XCTAssert(user_dictionary_name_profile_image_url == NSURL(string: "http://a0.twimg.com/profile_images/730275945/oauth-dancer_normal.jpg"))
+        XCTAssert(user_dictionary_name_profile_image_url == URL(string: "http://a0.twimg.com/profile_images/730275945/oauth-dancer_normal.jpg"))
     }
     
     func testJSONNumberCompare() {

--- a/Tests/StringTests.swift
+++ b/Tests/StringTests.swift
@@ -38,7 +38,7 @@ class StringTests: XCTestCase {
     
     func testURL() {
         let json = JSON("http://github.com")
-        XCTAssertEqual(json.URL!, NSURL(string:"http://github.com")!)
+        XCTAssertEqual(json.URL!, URL(string:"http://github.com")!)
     }
 
     func testURLPercentEscapes() {
@@ -46,6 +46,6 @@ class StringTests: XCTestCase {
         let urlString = "http://examble.com/unencoded" + emDash + "string"
         let encodedURLString = urlString.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
         let json = JSON(urlString)
-        XCTAssertEqual(json.URL!, NSURL(string: encodedURLString!)!, "Wrong unpacked ")
+        XCTAssertEqual(json.URL!, URL(string: encodedURLString!)!, "Wrong unpacked ")
     }
 }


### PR DESCRIPTION
With Swift 3, the NS prefix is dropped from several Foundation classes, including `NSURL`, to avoid casting between classes SwiftyJSON should use `URL` instead as this is the default class in Swift 3 now.