### PR TITLE
Remove nil convertable

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -524,7 +524,8 @@ extension JSON: Swift.ExpressibleByArrayLiteral {
 }
 
 extension JSON: Swift.ExpressibleByNilLiteral {
-    
+
+    @available(*, deprecated, message: "use JSON.null instead. Will be removed in future versions")
     public init(nilLiteral: ()) {
         self.init(NSNull() as Any)
     }

--- a/Tests/BaseTests.swift
+++ b/Tests/BaseTests.swift
@@ -201,11 +201,11 @@ class BaseTests: XCTestCase {
     func testNullJSON() {
         XCTAssertEqual(JSON(NSNull()).debugDescription,"null")
         
-        let json:JSON = nil
+        let json:JSON = JSON.null
         XCTAssertEqual(json.debugDescription,"null")
         XCTAssertNil(json.error)
         let json1:JSON = JSON(NSNull())
-        if json1 != nil {
+        if json1 != JSON.null {
             XCTFail("json1 should be nil")
         }
     }

--- a/Tests/ComparableTests.swift
+++ b/Tests/ComparableTests.swift
@@ -297,7 +297,7 @@ class ComparableTests: XCTestCase {
     }
 
     func testNil() {
-        let jsonL1:JSON = nil
+        let jsonL1:JSON = JSON.null
         let jsonR1:JSON = JSON(NSNull())
         XCTAssertEqual(jsonL1, jsonR1)
         XCTAssertTrue(jsonL1 != "123")

--- a/Tests/LiteralConvertibleTests.swift
+++ b/Tests/LiteralConvertibleTests.swift
@@ -51,12 +51,12 @@ class LiteralConvertibleTests: XCTestCase {
     }
     
     func testNil() {
-        let jsonNil_1:JSON = nil
-        XCTAssert(jsonNil_1 == nil)
+        let jsonNil_1:JSON = JSON.null
+        XCTAssert(jsonNil_1 == JSON.null)
         let jsonNil_2:JSON = JSON(NSNull.self)
-        XCTAssert(jsonNil_2 != nil)
+        XCTAssert(jsonNil_2 != JSON.null)
         let jsonNil_3:JSON = JSON([1:2])
-        XCTAssert(jsonNil_3 != nil)
+        XCTAssert(jsonNil_3 != JSON.null)
     }
     
     func testArray() {

--- a/Tests/PrintableTests.swift
+++ b/Tests/PrintableTests.swift
@@ -46,7 +46,7 @@ class PrintableTests: XCTestCase {
     }
     
     func testNil() {
-        let jsonNil_1:JSON = nil
+        let jsonNil_1:JSON = JSON.null
         XCTAssertEqual(jsonNil_1.description, "null")
         XCTAssertEqual(jsonNil_1.debugDescription, "null")
         let jsonNil_2:JSON = JSON(NSNull())

--- a/Tests/RawTests.swift
+++ b/Tests/RawTests.swift
@@ -92,7 +92,7 @@ class RawTests: XCTestCase {
     }
     
     func testNull() {
-        let json:JSON = nil
+        let json:JSON = JSON.null
         print(json.rawString())
         XCTAssertTrue(json.rawString() == "null")
     }

--- a/Tests/SubscriptTests.swift
+++ b/Tests/SubscriptTests.swift
@@ -224,7 +224,7 @@ class SubscriptTests: XCTestCase {
         var json:JSON = [[[[["num":1]]]]]
         json[0, 0, 0, 0, "num"] = 2
         XCTAssertEqual(json[[0, 0, 0, 0, "num"]].intValue, 2)
-        json[0, 0, 0, 0, "num"] = nil
+        json[0, 0, 0, 0, "num"] = JSON.null
         XCTAssertEqual(json[0, 0, 0, 0, "num"].null!, NSNull())
         json[0, 0, 0, 0, "num"] = 100.009
         XCTAssertEqual(json[0][0][0][0]["num"].doubleValue, 100.009)


### PR DESCRIPTION
First step to remove adoption of `NilLiteralConvertible`
https://github.com/SwiftyJSON/SwiftyJSON/issues/670

Thanks to @Igor-Palaguta