### PR TITLE
Match pre-swift3 behavior for String -> Bool

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -711,7 +711,9 @@ extension JSON { // : Swift.Bool
             case .number:
                 return self.rawNumber.boolValue
             case .string:
-                return self.rawString.caseInsensitiveCompare("true") == .orderedSame
+                return ["true", "y", "t"].contains() { (truthyString) in
+                    return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
+                }
             default:
                 return false
             }

--- a/Tests/StringTests.swift
+++ b/Tests/StringTests.swift
@@ -41,6 +41,21 @@ class StringTests: XCTestCase {
         XCTAssertEqual(json.URL!, URL(string:"http://github.com")!)
     }
 
+    func testBool() {
+        let json = JSON("true")
+        XCTAssertTrue(json.boolValue)
+    }
+
+    func testBoolWithY() {
+        let json = JSON("Y")
+        XCTAssertTrue(json.boolValue)
+    }
+
+    func testBoolWithT() {
+        let json = JSON("T")
+        XCTAssertTrue(json.boolValue)
+    }
+
     func testURLPercentEscapes() {
         let emDash = "\\u2014"
         let urlString = "http://examble.com/unencoded" + emDash + "string"


### PR DESCRIPTION
Before the Swift 3 update, boolValue used the NSString boolvalue
property. This property would return true for 'Y','y','T','t' in
addition to 'true'.

See more at:
https://developer.apple.com/reference/foundation/nsstring/1409420-boolvalue

Change Introduced in:
cf657820fad3656df022d8ebf32f9cdd99e1247a

During the swift 3 upgrade, this was changed slightly so only "true"
would return true. This commit updates that behavior to match the
previous behavior for projects relying on that functionality.