### PR TITLE
Fix issue #603 Improve example with push segue

### DIFF
--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -60,7 +60,7 @@
                                     </subviews>
                                 </tableViewCellContentView>
                                 <connections>
-                                    <segue destination="UBk-MQ-XCB" kind="showDetail" id="sAK-oo-Wa8"/>
+                                    <segue destination="yoh-b6-vfD" kind="show" id="9x2-N4-tQp"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -79,4 +79,7 @@
             <point key="canvasLocation" x="1092" y="-18"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="o6q-xz-i46"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -69,12 +69,7 @@ class ViewController: UITableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any!) {
 
         var nextController: UIViewController?
-        switch UIDevice.current.systemVersion.compare("8.0.0", options: NSString.CompareOptions.numeric) {
-        case .orderedSame, .orderedDescending:
-            nextController = (segue.destination as! UINavigationController).topViewController
-        case .orderedAscending:
-            nextController = segue.destination
-        }
+        nextController = segue.destination
         
         if let indexPath = self.tableView.indexPathForSelectedRow {
             let row = (indexPath as NSIndexPath).row


### PR DESCRIPTION
The previous segue is pointed to the navigation controller. This causes the show segue to be presented instead on the current navigation controller. Attaching the segue to the view controller itself.