### PR TITLE
Fix warning In XCode 8.1 (8B62)

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -856,7 +856,7 @@ extension JSON {
             }
         }
         set {
-            self.object = newValue?.absoluteString
+            self.object = newValue?.absoluteString ?? NSNull()
         }
     }
 }


### PR DESCRIPTION
Expression implicitly coerced from 'String?' to Any
