### PR TITLE
Fixes #692 - Need to check for Int8, a special case

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -157,9 +157,6 @@ public struct JSON {
         set {
             _error = nil
             switch newValue {
-            case let int8Value as Int8 where type(of: newValue) == Int8.self:
-                _type = .number
-                self.rawNumber = NSNumber(value: Int(int8Value))
             case let number as NSNumber:
                 if number.isBool {
                     _type = .bool
@@ -967,7 +964,7 @@ extension JSON {
         }
         set {
             if let newValue = newValue {
-                self.object = newValue
+                self.object = NSNumber(value: Int(newValue))
             } else {
                 self.object =  NSNull()
             }
@@ -979,7 +976,7 @@ extension JSON {
             return self.numberValue.int8Value
         }
         set {
-            self.object = newValue
+            self.object = NSNumber(value: Int(newValue))
         }
     }
     

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -157,6 +157,9 @@ public struct JSON {
         set {
             _error = nil
             switch newValue {
+            case let int8Value as Int8 where type(of: newValue) == Int8.self:
+                _type = .number
+                self.rawNumber = NSNumber(value: Int(int8Value))
             case let number as NSNumber:
                 if number.isBool {
                     _type = .bool
@@ -964,7 +967,7 @@ extension JSON {
         }
         set {
             if let newValue = newValue {
-                self.object = NSNumber(value: newValue)
+                self.object = newValue
             } else {
                 self.object =  NSNull()
             }
@@ -976,7 +979,7 @@ extension JSON {
             return self.numberValue.int8Value
         }
         set {
-            self.object = NSNumber(value: newValue)
+            self.object = newValue
         }
     }
     

--- a/Tests/SwiftyJSONTests/NumberTests.swift
+++ b/Tests/SwiftyJSONTests/NumberTests.swift
@@ -192,11 +192,7 @@ class NumberTests: XCTestCase {
         print(json.number)
         XCTAssertTrue(json.number! == n0)
         XCTAssertEqual(json.numberValue, n0)
-        #if (arch(x86_64) || arch(arm64))
-           XCTAssertEqual(json.stringValue, "false")
-        #elseif (arch(i386) || arch(arm))
-            XCTAssertEqual(json.stringValue, "0")
-        #endif
+        XCTAssertEqual(json.stringValue, "0")
         
         
         let n1 = NSNumber(value: 1 as Int8)
@@ -205,11 +201,7 @@ class NumberTests: XCTestCase {
         XCTAssertTrue(json.int8Value == n1.int8Value)
         XCTAssertTrue(json.number! == n1)
         XCTAssertEqual(json.numberValue, n1)
-        #if (arch(x86_64) || arch(arm64))
-            XCTAssertEqual(json.stringValue, "true")
-        #elseif (arch(i386) || arch(arm))
-            XCTAssertEqual(json.stringValue, "1")
-        #endif
+        XCTAssertEqual(json.stringValue, "1")
     }
     
     func testUInt8() {


### PR DESCRIPTION
The `isBool` function on the NSNumber extension uses `trueObjCType`, which represents the type encoding for `true` represented as an NSNumber, and `falseObjCType`, which represents the type encoding for `false` represented as an NSNumber. Both type encodings are equal to `c`. However, an NSNumber that wraps around a value of type Int8 also has a type encoding of `c`.

Therefore, a user who passes in a value of 0 or 1 (of type Int8) into JSON will expect to see the numbers 0 or 1 as the output because that was the intent. Unfortunately, that value will be wrapped into NSNumber and be considered a bool, so the user will see `true` or `false` instead.

To fix this, when setting a new value of type Int8 on the computed properties `int8` or `int8Value`, the new value should be used to directly set `object`, which should then check for the Int8 type and use an Int instead. This is fine because an Int8 converted to an Int will always work and retain the same behavior of the JSON module, and also because the user`s intent is to use a number, not a boolean.

Having said that, the tests for `stringValue` on Int8 don't test the right thing. The user's intent is to use an integer, which is a number. However, the tests assume hardware implementation and accept the fact that it can either be true or false, which is unintuitive. Int8 is a pragmatic refinement to the semantic meaning of an integer, and should therefore be used as a number like the user intends, not a boolean.