### PR TITLE
Added a function to deep merge a JSON object into another JSON object…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@
 
 - Allow .number to parse number from string instead of just numberValue [\#219](https://github.com/SwiftyJSON/SwiftyJSON/pull/219) ([yonaskolb](https://github.com/yonaskolb))
 
-- Fixed spelling and grammar mistakes in README.md. Made some swift syntax... [\#214](https://github.com/SwiftyJSON/SwiftyJSON/pull/214) ([pRizz](https://github.com/pRizz))
+- Fixed spelling and grammar mistakes in README.md. Made some swift syntax... [\#214](https://github.com/SwiftyJSON/SwiftyJSON/pull/725) ([danielkiedrowski](https://github.com/danielkiedrowski))
+
+- Added a function to deep merge a JSON object into another JSON object... [\#725](https://github.com/SwiftyJSON/SwiftyJSON/pull/219) ([yonaskolb](https://github.com/yonaskolb))
 
 ## [2.2.0](https://github.com/SwiftyJSON/SwiftyJSON/tree/2.2.0) (2015-04-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@
 
 - Allow .number to parse number from string instead of just numberValue [\#219](https://github.com/SwiftyJSON/SwiftyJSON/pull/219) ([yonaskolb](https://github.com/yonaskolb))
 
-- Fixed spelling and grammar mistakes in README.md. Made some swift syntax... [\#214](https://github.com/SwiftyJSON/SwiftyJSON/pull/725) ([danielkiedrowski](https://github.com/danielkiedrowski))
+- Fixed spelling and grammar mistakes in README.md. Made some swift syntax... [\#214](https://github.com/SwiftyJSON/SwiftyJSON/pull/214) ([pRizz](https://github.com/pRizz))
 
-- Added a function to deep merge a JSON object into another JSON object... [\#725](https://github.com/SwiftyJSON/SwiftyJSON/pull/219) ([yonaskolb](https://github.com/yonaskolb))
+- Added a function to deep merge a JSON object into another JSON object... [\#725](https://github.com/SwiftyJSON/SwiftyJSON/pull/725) ([danielkiedrowski](https://github.com/danielkiedrowski))
 
 ## [2.2.0](https://github.com/SwiftyJSON/SwiftyJSON/tree/2.2.0) (2015-04-13)
 

--- a/README.md
+++ b/README.md
@@ -452,43 +452,43 @@ If both JSONs contain a value for the same key, _mostly_ this value gets overwri
 - In case of both values being a `JSON.Type.array` the values form the array found in the `other` JSON getting appended to the original JSON's array value. 
 - In case of both values being a `JSON.Type.dictionary` both JSON-values are getting merged the same way the encapsulating JSON is merged.
 
-In case, where two fields in a JSON have a different types, the value will get  always overwritten.
+In case, where two fields in a JSON have a different types, the value will get always overwritten.
 
-There are two different fashions for merging: `merge`modifies the original JSON, whereas `merged` works non-destructively on a copy.
+There are two different fashions for merging: `merge` modifies the original JSON, whereas `merged` works non-destructively on a copy.
 
 ```swift
 let original: JSON = [
-	"first_name": "John",
-	"age": 20,
-	"skills": ["Coding", "Reading"],
-	"address": [
-		"street": "Front St",
-		"zip": "12345",
-	]
+    "first_name": "John",
+    "age": 20,
+    "skills": ["Coding", "Reading"],
+    "address": [
+        "street": "Front St",
+        "zip": "12345",
+    ]
 ]
 
 let update: JSON = [
-	"last_name": "Doe",
-	"age": 21,
-	"skills": ["Writing"],
-	"address": [
-		"zip": "12342",
-		"city": "New York City"
-	]
+    "last_name": "Doe",
+    "age": 21,
+    "skills": ["Writing"],
+    "address": [
+        "zip": "12342",
+        "city": "New York City"
+    ]
 ]
 
 let updated = original.merge(with: update)
 // [
-//		"first_name": "John",
-//		"last_name": "Doe",
-//		"age": 21,
-//		"skills": ["Coding", "Reading", "Writing"],
-//		"address": [
-//			"street": "Front St",
-//			"zip": "12342",
-//			"city": "New York City"
-//		]
-//	]
+//     "first_name": "John",
+//     "last_name": "Doe",
+//     "age": 21,
+//     "skills": ["Coding", "Reading", "Writing"],
+//     "address": [
+//         "street": "Front St",
+//         "zip": "12342",
+//         "city": "New York City"
+//     ]
+// ]
 ```
 
 ## String representation

--- a/README.md
+++ b/README.md
@@ -442,6 +442,54 @@ let auth: JSON = [
 ]
 ```
 
+#### Merging
+
+It is possible to merge one JSON into another JSON. Merging a JSON into another JSON adds all non existing values to the original JSON which are only present in the `other` JSON.
+
+If both JSONs contain a value for the same key, _mostly_ this value gets overwritten in the original JSON, but there are two cases where it provides some special treatment:
+
+- In case of both values being a `JSON.Type.array` the values form the array found in the `other` JSON getting appended to the original JSON's array value. 
+- In case of both values being a `JSON.Type.dictionary` both JSON-values are getting merged the same way the encapsulating JSON is merged.
+
+In case, where two fields in a JSON have a different types, the value will get  always overwritten.
+
+There are two different fashions for merging: `merge`modifies the original JSON, whereas `merged` works non-destructively on a copy.
+
+```swift
+let original: JSON = [
+	"first_name": "John",
+	"age": 20,
+	"skills": ["Coding", "Reading"],
+	"address": [
+		"street": "Front St",
+		"zip": "12345",
+	]
+]
+
+let update: JSON = [
+	"last_name": "Doe",
+	"age": 21,
+	"skills": ["Writing"],
+	"address": [
+		"zip": "12342",
+		"city": "New York City"
+	]
+]
+
+let updated = original.merge(with: update)
+// [
+//		"first_name": "John",
+//		"last_name": "Doe",
+//		"age": 21,
+//		"skills": ["Coding", "Reading", "Writing"],
+//		"address": [
+//			"street": "Front St",
+//			"zip": "12342",
+//			"city": "New York City"
+//		]
+//	]
+```
+
 ## String representation
 There are two options available:
 - use the default Swift one

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ SwiftyJSON makes it easy to deal with JSON data in Swift.
    - [Setter](#setter)
    - [Raw object](#raw-object)
    - [Literal convertibles](#literal-convertibles)
+   - [Merging](#merging)
 5. [Work with Alamofire](#work-with-alamofire)
 
 > For Legacy Swift support, take a look at the [swift2 branch](https://github.com/SwiftyJSON/SwiftyJSON/tree/swift2)

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -131,20 +131,7 @@ public struct JSON {
      - parameter other: The JSON which gets merged into this JSON
      */
     public mutating func merge(with other: JSON) {
-        if self.type == other.type {
-            switch self.type {
-            case .dictionary:
-                for (key, _) in other {
-                    self[key].merge(with: other[key])
-                }
-            case .array:
-                self = JSON(self.arrayValue + other.arrayValue)
-            default:
-                self = other
-            }
-        } else {
-            self = other
-        }
+        self.merge(with: other, typecheck: true)
     }
     
     /**
@@ -156,8 +143,31 @@ public struct JSON {
      */
     public func merged(with other: JSON) -> JSON {
         var merged = self
-        merged.merge(with: other)
+        merged.merge(with: other, typecheck: true)
         return merged
+    }
+    
+    // Private woker function which does the actual merging
+    // Typecheck is set to true for the first recursion level to prevent total override of the source JSON
+    private mutating func merge(with other: JSON, typecheck: Bool) {
+        if self.type == other.type {
+            switch self.type {
+            case .dictionary:
+                for (key, _) in other {
+                    self[key].merge(with: other[key], typecheck: false)
+                }
+            case .array:
+                self = JSON(self.arrayValue + other.arrayValue)
+            default:
+                self = other
+            }
+        } else {
+            if typecheck {
+                print("Couldn't merge, because the JSONs differ in type on top level.")
+            } else {
+                self = other
+            }
+        }
     }
 
     /// Private object

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -123,6 +123,42 @@ public struct JSON {
         }
         self.init(dictionary)
     }
+    
+    /**
+     Merges another JSON into this JSON, whereas primitive values which are not present in this JSON are getting added, 
+     present values getting overwritten, array values getting appended and nested JSONs getting merged the same way.
+ 
+     - parameter other: The JSON which gets merged into this JSON
+     */
+    public mutating func merge(_ other: JSON) {
+        if self.type == other.type {
+            switch self.type {
+            case .dictionary:
+                for (key, _) in other {
+                    self[key].merge(other[key])
+                }
+            case .array:
+                self = JSON(self.arrayValue + other.arrayValue)
+            default:
+                self = other
+            }
+        } else {
+            self = other
+        }
+    }
+    
+    /**
+     Merges another JSON into this JSON and returns a new JSON, whereas primitive values which are not present in this JSON are getting added,
+     present values getting overwritten, array values getting appended and nested JSONS getting merged the same way.
+     
+     - parameter other: The JSON which gets merged into this JSON
+     - returns: New merged JSON
+     */
+    public func merged(other: JSON) -> JSON {
+        var merged = self
+        merged.merge(other)
+        return merged
+    }
 
     /// Private object
     fileprivate var rawArray: [Any] = []

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -129,9 +129,10 @@ public struct JSON {
      present values getting overwritten, array values getting appended and nested JSONs getting merged the same way.
  
      - parameter other: The JSON which gets merged into this JSON
+     - throws `ErrorWrongType` if the other JSONs differs in type on the top level.
      */
-    public mutating func merge(with other: JSON) {
-        self.merge(with: other, typecheck: true)
+    public mutating func merge(with other: JSON) throws {
+        try self.merge(with: other, typecheck: true)
     }
     
     /**
@@ -140,21 +141,22 @@ public struct JSON {
      
      - parameter other: The JSON which gets merged into this JSON
      - returns: New merged JSON
+     - throws `ErrorWrongType` if the other JSONs differs in type on the top level.
      */
-    public func merged(with other: JSON) -> JSON {
+    public func merged(with other: JSON) throws -> JSON {
         var merged = self
-        merged.merge(with: other, typecheck: true)
+        try merged.merge(with: other, typecheck: true)
         return merged
     }
     
     // Private woker function which does the actual merging
     // Typecheck is set to true for the first recursion level to prevent total override of the source JSON
-    private mutating func merge(with other: JSON, typecheck: Bool) {
+    private mutating func merge(with other: JSON, typecheck: Bool) throws {
         if self.type == other.type {
             switch self.type {
             case .dictionary:
                 for (key, _) in other {
-                    self[key].merge(with: other[key], typecheck: false)
+                    try self[key].merge(with: other[key], typecheck: false)
                 }
             case .array:
                 self = JSON(self.arrayValue + other.arrayValue)
@@ -163,7 +165,7 @@ public struct JSON {
             }
         } else {
             if typecheck {
-                print("Couldn't merge, because the JSONs differ in type on top level.")
+                throw NSError(domain: ErrorDomain, code: ErrorWrongType, userInfo: [NSLocalizedDescriptionKey: "Couldn't merge, because the JSONs differ in type on top level."])
             } else {
                 self = other
             }

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -130,12 +130,12 @@ public struct JSON {
  
      - parameter other: The JSON which gets merged into this JSON
      */
-    public mutating func merge(_ other: JSON) {
+    public mutating func merge(with other: JSON) {
         if self.type == other.type {
             switch self.type {
             case .dictionary:
                 for (key, _) in other {
-                    self[key].merge(other[key])
+                    self[key].merge(with: other[key])
                 }
             case .array:
                 self = JSON(self.arrayValue + other.arrayValue)
@@ -154,9 +154,9 @@ public struct JSON {
      - parameter other: The JSON which gets merged into this JSON
      - returns: New merged JSON
      */
-    public func merged(other: JSON) -> JSON {
+    public func merged(with other: JSON) -> JSON {
         var merged = self
-        merged.merge(other)
+        merged.merge(with: other)
         return merged
     }
 

--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1B587CC61DDE04770012D8DB /* MergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B587CC41DDE04360012D8DB /* MergeTests.swift */; };
+		1B587CC71DDE04780012D8DB /* MergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B587CC41DDE04360012D8DB /* MergeTests.swift */; };
+		1B587CC81DDE04790012D8DB /* MergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B587CC41DDE04360012D8DB /* MergeTests.swift */; };
 		2E4FEFE119575BE100351305 /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2E4FEFE719575BE100351305 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E4FEFDB19575BE100351305 /* SwiftyJSON.framework */; };
 		5DD502911D9B21810004C112 /* NestedJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD502901D9B21810004C112 /* NestedJSONTests.swift */; };
@@ -91,6 +94,7 @@
 
 /* Begin PBXFileReference section */
 		030B6CDC1A6E171D00C2D4F1 /* Info-OSX.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-OSX.plist"; sourceTree = "<group>"; };
+		1B587CC41DDE04360012D8DB /* MergeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MergeTests.swift; sourceTree = "<group>"; };
 		2E4FEFDB19575BE100351305 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E4FEFDF19575BE100351305 /* Info-iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
 		2E4FEFE019575BE100351305 /* SwiftyJSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftyJSON.h; sourceTree = "<group>"; };
@@ -226,6 +230,7 @@
 		2E4FEFEA19575BE100351305 /* SwiftyJSONTests */ = {
 			isa = PBXGroup;
 			children = (
+				1B587CC41DDE04360012D8DB /* MergeTests.swift */,
 				A885D1DA19CFCFF0002FD4C3 /* Tests.json */,
 				A86BAA0D19EBC32B009EAAEB /* PerformanceTests.swift */,
 				A885D1D119CF1EE6002FD4C3 /* BaseTests.swift */,
@@ -550,6 +555,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1B587CC61DDE04770012D8DB /* MergeTests.swift in Sources */,
 				A87080E819E439DA00CDE086 /* NumberTests.swift in Sources */,
 				A87080E419E3C2A600CDE086 /* SequenceTypeTests.swift in Sources */,
 				5DD502911D9B21810004C112 /* NestedJSONTests.swift in Sources */,
@@ -587,6 +593,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1B587CC71DDE04780012D8DB /* MergeTests.swift in Sources */,
 				9C459EFB1A9103C1008C9A41 /* SequenceTypeTests.swift in Sources */,
 				9C459F001A9103C1008C9A41 /* ComparableTests.swift in Sources */,
 				5DD502921D9B21810004C112 /* NestedJSONTests.swift in Sources */,
@@ -608,6 +615,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1B587CC81DDE04790012D8DB /* MergeTests.swift in Sources */,
 				A8580F801BCF69A000DA927B /* PerformanceTests.swift in Sources */,
 				A8580F811BCF69A000DA927B /* BaseTests.swift in Sources */,
 				5DD502931D9B21810004C112 /* NestedJSONTests.swift in Sources */,

--- a/Tests/SwiftyJSONTests/MergeTests.swift
+++ b/Tests/SwiftyJSONTests/MergeTests.swift
@@ -25,6 +25,13 @@ import XCTest
 import SwiftyJSON
 
 class JSONTests: XCTestCase {
+    
+    func testDifferingTypes() {
+        let A = JSON("a")
+        let B = JSON(1)
+        XCTAssertEqual(A.merged(with: B), A)
+    }
+    
     func testPrimitiveType() {
         let A = JSON("a")
         let B = JSON("b")

--- a/Tests/SwiftyJSONTests/MergeTests.swift
+++ b/Tests/SwiftyJSONTests/MergeTests.swift
@@ -29,48 +29,58 @@ class JSONTests: XCTestCase {
     func testDifferingTypes() {
         let A = JSON("a")
         let B = JSON(1)
-        XCTAssertEqual(A.merged(with: B), A)
+        
+        do {
+            _ = try A.merged(with: B)
+            XCTFail()
+        } catch (let error) {
+            let error = error as NSError
+            XCTAssertEqual(error.code, ErrorWrongType)
+            XCTAssertEqual(error.domain, ErrorDomain)
+            XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey] as! String,
+                           "Couldn't merge, because the JSONs differ in type on top level.")
+        }
     }
     
     func testPrimitiveType() {
         let A = JSON("a")
         let B = JSON("b")
-        XCTAssertEqual(A.merged(with: B), B)
+        XCTAssertEqual(try! A.merged(with: B), B)
     }
     
     func testMergeEqual() {
         let json = JSON(["a": "A"])
-        XCTAssertEqual(json.merged(with: json), json)
+        XCTAssertEqual(try! json.merged(with: json), json)
     }
     
     func testMergeUnequalValues() {
         let A = JSON(["a": "A"])
         let B = JSON(["a": "B"])
-        XCTAssertEqual(A.merged(with: B), B)
+        XCTAssertEqual(try! A.merged(with: B), B)
     }
     
     func testMergeUnequalKeysAndValues() {
         let A = JSON(["a": "A"])
         let B = JSON(["b": "B"])
-        XCTAssertEqual(A.merged(with: B), JSON(["a": "A", "b": "B"]))
+        XCTAssertEqual(try! A.merged(with: B), JSON(["a": "A", "b": "B"]))
     }
     
     func testMergeFilledAndEmpty() {
         let A = JSON(["a": "A"])
         let B = JSON([:])
-        XCTAssertEqual(A.merged(with: B), A)
+        XCTAssertEqual(try! A.merged(with: B), A)
     }
     
     func testMergeEmptyAndFilled() {
         let A = JSON([:])
         let B = JSON(["a": "A"])
-        XCTAssertEqual(A.merged(with: B), B)
+        XCTAssertEqual(try! A.merged(with: B), B)
     }
     
     func testMergeArray() {
         let A = JSON(["a"])
         let B = JSON(["b"])
-        XCTAssertEqual(A.merged(with: B), JSON(["a", "b"]))
+        XCTAssertEqual(try! A.merged(with: B), JSON(["a", "b"]))
     }
     
     func testMergeNestedJSONs() {
@@ -86,6 +96,6 @@ class JSONTests: XCTestCase {
             ]
         ])
         
-        XCTAssertEqual(A.merged(with: B), B)
+        XCTAssertEqual(try! A.merged(with: B), B)
     }
 }

--- a/Tests/SwiftyJSONTests/MergeTests.swift
+++ b/Tests/SwiftyJSONTests/MergeTests.swift
@@ -1,0 +1,84 @@
+//
+//  JSONTests.swift
+//
+//  Created by Daniel Kiedrowski on 17.11.16.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import XCTest
+import SwiftyJSON
+
+class JSONTests: XCTestCase {
+    func testPrimitiveType() {
+        let A = JSON("a")
+        let B = JSON("b")
+        XCTAssertEqual(A.merged(other: B), B)
+    }
+    
+    func testMergeEqual() {
+        let json = JSON(["a": "A"])
+        XCTAssertEqual(json.merged(other: json), json)
+    }
+    
+    func testMergeUnequalValues() {
+        let A = JSON(["a": "A"])
+        let B = JSON(["a": "B"])
+        XCTAssertEqual(A.merged(other: B), B)
+    }
+    
+    func testMergeUnequalKeysAndValues() {
+        let A = JSON(["a": "A"])
+        let B = JSON(["b": "B"])
+        XCTAssertEqual(A.merged(other: B), JSON(["a": "A", "b": "B"]))
+    }
+    
+    func testMergeFilledAndEmpty() {
+        let A = JSON(["a": "A"])
+        let B = JSON([:])
+        XCTAssertEqual(A.merged(other: B), A)
+    }
+    
+    func testMergeEmptyAndFilled() {
+        let A = JSON([:])
+        let B = JSON(["a": "A"])
+        XCTAssertEqual(A.merged(other: B), B)
+    }
+    
+    func testMergeArray() {
+        let A = JSON(["a"])
+        let B = JSON(["b"])
+        XCTAssertEqual(A.merged(other: B), JSON(["a", "b"]))
+    }
+    
+    func testMergeNestedJSONs() {
+        let A = JSON([
+            "nested": [
+                "A": "a"
+            ]
+        ])
+        
+        let B = JSON([
+            "nested": [
+                "A": "b"
+            ]
+        ])
+        
+        XCTAssertEqual(A.merged(other: B), B)
+    }
+}

--- a/Tests/SwiftyJSONTests/MergeTests.swift
+++ b/Tests/SwiftyJSONTests/MergeTests.swift
@@ -28,42 +28,42 @@ class JSONTests: XCTestCase {
     func testPrimitiveType() {
         let A = JSON("a")
         let B = JSON("b")
-        XCTAssertEqual(A.merged(other: B), B)
+        XCTAssertEqual(A.merged(with: B), B)
     }
     
     func testMergeEqual() {
         let json = JSON(["a": "A"])
-        XCTAssertEqual(json.merged(other: json), json)
+        XCTAssertEqual(json.merged(with: json), json)
     }
     
     func testMergeUnequalValues() {
         let A = JSON(["a": "A"])
         let B = JSON(["a": "B"])
-        XCTAssertEqual(A.merged(other: B), B)
+        XCTAssertEqual(A.merged(with: B), B)
     }
     
     func testMergeUnequalKeysAndValues() {
         let A = JSON(["a": "A"])
         let B = JSON(["b": "B"])
-        XCTAssertEqual(A.merged(other: B), JSON(["a": "A", "b": "B"]))
+        XCTAssertEqual(A.merged(with: B), JSON(["a": "A", "b": "B"]))
     }
     
     func testMergeFilledAndEmpty() {
         let A = JSON(["a": "A"])
         let B = JSON([:])
-        XCTAssertEqual(A.merged(other: B), A)
+        XCTAssertEqual(A.merged(with: B), A)
     }
     
     func testMergeEmptyAndFilled() {
         let A = JSON([:])
         let B = JSON(["a": "A"])
-        XCTAssertEqual(A.merged(other: B), B)
+        XCTAssertEqual(A.merged(with: B), B)
     }
     
     func testMergeArray() {
         let A = JSON(["a"])
         let B = JSON(["b"])
-        XCTAssertEqual(A.merged(other: B), JSON(["a", "b"]))
+        XCTAssertEqual(A.merged(with: B), JSON(["a", "b"]))
     }
     
     func testMergeNestedJSONs() {
@@ -79,6 +79,6 @@ class JSONTests: XCTestCase {
             ]
         ])
         
-        XCTAssertEqual(A.merged(other: B), B)
+        XCTAssertEqual(A.merged(with: B), B)
     }
 }


### PR DESCRIPTION
… destructively and non-destructively.

I added two new functions `merge(other: JSON)` and `merged(other: JSON) -> JSON`. Merging a JSON into another JSON adds all non existing values to the original JSON which are only present in the `other` JSON.

If both JSONs contain a value for the same key, _mostly_ this value gets overwritten in the original JSON, but there are two cases where it provides some special treatment:

- In case of both values being a `JSON.Type.array` the values form the array found in the `other` JSON getting appended to the original JSON's array value. 
- In case of both values being a `JSON.Type.dictionary` both JSON-values are getting merged the same way the encapsulating JSON is merged.

`merge`mutates the original JSON, whereas `merged` works non-destructively on a copy.

I found this to be an issue due to a stackoverflow.com post and posted my [answer](http://stackoverflow.com/questions/30427516/how-to-combine-two-swiftyjson-objects/40656255#40656255) there, but also think that this functions might be a good addition to the SwiftJSON project in general.