### PR TITLE
Added init(jsonString) and made init(data) throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,13 @@
 
 - It seems not easy to manipulate an array or dictionary? [\#110](https://github.com/SwiftyJSON/SwiftyJSON/issues/110)
 
+- Document JSON.parse() usage in README [\#459](https://github.com/SwiftyJSON/SwiftyJSON/issues/459)
+
 **Merged pull requests:**
+
+- **Breaking**: Removed `SwiftyJSON.parse` and added `init(jsonString:)`. [\#731](https://github.com/SwiftyJSON/SwiftyJSON/pull/731)
+
+- **Breaking**: `init(data:)` now throws if the data cannot be converted to a proper JSON object. [\#731](https://github.com/SwiftyJSON/SwiftyJSON/pull/731)
 
 - Fix for xcode 6.3..1 issue [\#224](https://github.com/SwiftyJSON/SwiftyJSON/pull/224) ([datomnurdin](https://github.com/datomnurdin))
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ An unreadable mess--for something that should really be simple!
 With SwiftyJSON all you have to do is:
 
 ```swift
-let json = JSON(data: dataFromNetworking)
+let json = try JSON(data: dataFromNetworking)
 if let userName = json[0]["user"]["name"].string {
   //Now you got your value
 }
@@ -65,7 +65,7 @@ if let userName = json[0]["user"]["name"].string {
 And don't worry about the Optional Wrapping thing. It's done for you automatically.
 
 ```swift
-let json = JSON(data: dataFromNetworking)
+let json = try JSON(data: dataFromNetworking)
 if let userName = json[999999]["wrong_key"]["wrong_name"].string {
     //Calm down, take it easy, the ".string" property still produces the correct Optional String type with safety
 } else {
@@ -139,17 +139,15 @@ import SwiftyJSON
 ```
 
 ```swift
-let json = JSON(data: dataFromNetworking)
+let json = try JSON(data: data)
+```
+
+```swift
+let json = try JSON(jsonString: string)
 ```
 
 ```swift
 let json = JSON(jsonObject)
-```
-
-```swift
-if let dataFromString = jsonString.data(using: .utf8, allowLossyConversion: false) {
-    let json = JSON(data: dataFromString)
-}
 ```
 
 #### Subscript

--- a/Tests/SwiftyJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftyJSONTests/PerformanceTests.swift
@@ -45,28 +45,28 @@ class PerformanceTests: XCTestCase {
     func testInitPerformance() {
         self.measure() {
             for _ in 1...100 {
-                let json = JSON(data:self.testData)
-                XCTAssertTrue(json != JSON.null)
+                let json = try? JSON(data:self.testData)
+                XCTAssertNotNil(json)
             }
         }
     }
     
     func testObjectMethodPerformance() {
-        let json = JSON(data:self.testData)
+        let json = try? JSON(data:self.testData)
         self.measure() {
             for _ in 1...100 {
-                let object:Any? = json.object
-                XCTAssertTrue(object != nil)
+                let object:Any? = json?.object
+                XCTAssertNotNil(object)
             }
         }
     }
 
     func testArrayMethodPerformance() {
-        let json = JSON(data:self.testData)
+        let json = try? JSON(data:self.testData)
         self.measure() {
             for _ in 1...100 {
                 autoreleasepool{
-                    if let array = json.array {
+                    if let array = json?.array {
                         XCTAssertTrue(array.count > 0)
                     }
                 }
@@ -75,11 +75,11 @@ class PerformanceTests: XCTestCase {
     }
     
     func testDictionaryMethodPerformance() {
-        let json = JSON(data:testData)[0]
+        let json = try? JSON(data:testData)[0]
         self.measure() {
             for _ in 1...100 {
                 autoreleasepool{
-                    if let dictionary = json.dictionary {
+                    if let dictionary = json?.dictionary {
                         XCTAssertTrue(dictionary.count > 0)
                     }
                 }
@@ -88,12 +88,12 @@ class PerformanceTests: XCTestCase {
     }
     
     func testRawStringMethodPerformance() {
-        let json = JSON(data:testData)
+        let json = try? JSON(data:testData)
         self.measure() {
             for _ in 1...100 {
                 autoreleasepool{
-                    let string = json.rawString()
-                    XCTAssertTrue(string != nil)
+                    let string = json?.rawString()
+                    XCTAssertNotNil(string)
                 }
             }
         }

--- a/Tests/SwiftyJSONTests/SequenceTypeTests.swift
+++ b/Tests/SwiftyJSONTests/SequenceTypeTests.swift
@@ -26,24 +26,23 @@ import SwiftyJSON
 
 class SequenceTypeTests: XCTestCase {
 
-    func testJSONFile() {
-        if let file = Bundle(for:BaseTests.self).path(forResource: "Tests", ofType: "json") {
-            let testData = try? Data(contentsOf: URL(fileURLWithPath: file))
-            let json = JSON(data:testData!)
-            for (index, sub) in json {
-                switch (index as NSString).integerValue {
-                case 0:
-                    XCTAssertTrue(sub["id_str"] == "240558470661799936")
-                case 1:
-                    XCTAssertTrue(sub["id_str"] == "240556426106372096")
-                case 2:
-                    XCTAssertTrue(sub["id_str"] == "240539141056638977")
-                default:
-                    continue
-                }
+    func testJSONFile() throws {
+        guard let file = Bundle(for:BaseTests.self).path(forResource: "Tests", ofType: "json") else {
+            return XCTFail("Can't find the test JSON file")
+        }
+        let testData = try Data(contentsOf: URL(fileURLWithPath: file))
+        let json = try JSON(data: testData)
+        for (index, sub) in json {
+            switch (index as NSString).integerValue {
+            case 0:
+                XCTAssertTrue(sub["id_str"] == "240558470661799936")
+            case 1:
+                XCTAssertTrue(sub["id_str"] == "240556426106372096")
+            case 2:
+                XCTAssertTrue(sub["id_str"] == "240539141056638977")
+            default:
+                continue
             }
-        } else {
-            XCTFail("Can't find the test JSON file")
         }
     }
 


### PR DESCRIPTION
@zhigang1992 @wongzigii 

Fixes https://github.com/SwiftyJSON/SwiftyJSON/issues/459 and https://github.com/SwiftyJSON/SwiftyJSON/issues/456

This is an implementation of my proposal in https://github.com/SwiftyJSON/SwiftyJSON/issues/459#issuecomment-262155181. At a high level the changes are as follow:

 - Added `init(jsonString: String) throws` which creates a JSON object from a valid json string. If the string cannot be converted to data or parsed by NSJSONSerialization, the initializer will throw an appropriate error as opposed to failing silently.
 - Added documentation + tests around the new initializer and updated the README
 - Removed `JSON.parse` which was doing the same thing (but would fail silently)
 - Made `init(data: Data)` throw as well, to handle invalid JSON data coming through.

**This is a code breaking change** since `init(data: Data)` now throws.

Let me know what you think.