### PR TITLE
Change  boolValue when rawString is a number

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -835,8 +835,12 @@ extension JSON { // : Swift.Bool
             case .number:
                 return self.rawNumber.boolValue
             case .string:
-                return ["true", "y", "t"].contains() { (truthyString) in
-                    return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
+                if NSDecimalNumber(string: self.rawString) == NSDecimalNumber.notANumber {
+                    return ["true", "y", "t"].contains() { (truthyString) in
+                        return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
+                    }
+                } else {
+                    return self.intValue > 0
                 }
             default:
                 return false

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -835,12 +835,13 @@ extension JSON { // : Swift.Bool
             case .number:
                 return self.rawNumber.boolValue
             case .string:
-                if NSDecimalNumber(string: self.rawString) == NSDecimalNumber.notANumber {
+                let decimal = NSDecimalNumber(string: self.object as? String)
+                if decimal == NSDecimalNumber.notANumber {
                     return ["true", "y", "t"].contains() { (truthyString) in
                         return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
                     }
                 } else {
-                    return self.intValue != 0
+                    return decimal.boolValue
                 }
             default:
                 return false

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -840,7 +840,7 @@ extension JSON { // : Swift.Bool
                         return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
                     }
                 } else {
-                    return self.intValue > 0
+                    return self.intValue != 0
                 }
             default:
                 return false

--- a/Tests/SwiftyJSONTests/StringTests.swift
+++ b/Tests/SwiftyJSONTests/StringTests.swift
@@ -61,6 +61,7 @@ class StringTests: XCTestCase {
         XCTAssertFalse(json.boolValue)
         json = JSON("1")
         XCTAssertTrue(json.boolValue)
+        XCTAssertTrue(JSON("-1").boolValue == NSNumber(integerLiteral: -1).boolValue)
     }
 
     func testURLPercentEscapes() {

--- a/Tests/SwiftyJSONTests/StringTests.swift
+++ b/Tests/SwiftyJSONTests/StringTests.swift
@@ -55,6 +55,13 @@ class StringTests: XCTestCase {
         let json = JSON("T")
         XCTAssertTrue(json.boolValue)
     }
+    
+    func testBoolWithStringNumber() {
+        var json = JSON("0")
+        XCTAssertFalse(json.boolValue)
+        json = JSON("1")
+        XCTAssertTrue(json.boolValue)
+    }
 
     func testURLPercentEscapes() {
         let emDash = "\\u2014"


### PR DESCRIPTION
when get boolValue from rawString which is a number, it's opposite to the older version when use string.boolValue