### PR TITLE
Fix travis_retry command not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ before_deploy:
 - carthage build --no-skip-current
 - carthage archive $FRAMEWORK_NAME
 script:
-- sh scripts/ci.sh
+- set -o pipefail
+- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,name=iPhone 6" build-for-testing test | xcpretty
+- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON OSX" build-for-testing test | xcpretty
+- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON tvOS" -destination "platform=tvOS Simulator,name=Apple TV 1080p" build-for-testing test | xcpretty
 deploy:
   provider: releases
   api_key:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,name=iPhone 6" build-for-testing test | xcpretty
-
-travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON OSX" build-for-testing test | xcpretty
-
-travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON tvOS" -destination "platform=tvOS Simulator,name=Apple TV 1080p" build-for-testing test | xcpretty


### PR DESCRIPTION
Relate to #733. 

It seems like TravisCI does not support `travis_retry` to cooperate with an inner shell script. See this [tweet](https://twitter.com/plexus/status/499194992632811520).

> [CI Build Result](https://travis-ci.org/SwiftyJSON/SwiftyJSON/builds/178321916)
> scripts/ci.sh: line 5: travis_retry: command not found
> scripts/ci.sh: line 7: travis_retry: command not found
> scripts/ci.sh: line 9: travis_retry: command not found

So this PR will move scrips into `.travis.yml` and drop `ci.sh`.