### PR TITLE
Fix rawString output of String types

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -688,7 +688,7 @@ extension JSON: Swift.RawRepresentable {
                 return nil
             }
         case .string:
-            return self.rawString
+            return "\"\(self.rawString)\""
         case .number:
             return self.rawNumber.stringValue
         case .bool:


### PR DESCRIPTION
Raw representations of Strings in JSON should be enclosed in quotes.
As expected, numbers can be converted to string and back to JSON, but string values will return null:
```
(lldb) po JSON.parse(JSON(3).rawString()!)
▿ 3
  - _type : SwiftyJSON.Type.number
(lldb) po JSON.parse(JSON("test").rawString()!)
▿ null
  - _type : SwiftyJSON.Type.null
```
After fix is applied:
```
(lldb) po JSON.parse(JSON("test").rawString()!)
▿ "test"
  - _type : SwiftyJSON.Type.string
```