### PR TITLE
Fix init(data:) error handling:

### DIFF
--- a/Example/Playground.playground/Contents.swift
+++ b/Example/Playground.playground/Contents.swift
@@ -31,7 +31,7 @@ let jsonString = String(data: jsonData!, encoding: .utf8)
  */
 import SwiftyJSON
 
-let json1 = JSON(data: jsonData!)
+let json1 = try? JSON(data: jsonData!)
 /*:
  or
  */
@@ -40,7 +40,7 @@ let json2 = JSON(jsonObject)
  or
  */
 let dataFromString = jsonString?.data(using: .utf8)
-let json3 = JSON(data: dataFromString!)
+let json3 = try? JSON(data: dataFromString!)
 
 /*:
  ### Subscript

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -59,21 +59,14 @@ public struct JSON {
      Creates a JSON using the data.
 
      - parameter data:  The NSData used to convert to json.Top level object in data is an NSArray or NSDictionary
-     - parameter opt:   The JSON serialization reading options. `.AllowFragments` by default.
+     - parameter opt:   The JSON serialization reading options. `[]` by default.
      - parameter error: The NSErrorPointer used to return the error. `nil` by default.
 
      - returns: The created JSON
      */
-    public init(data: Data, options opt: JSONSerialization.ReadingOptions = .allowFragments, error: NSErrorPointer = nil) {
-        do {
-            let object: Any = try JSONSerialization.jsonObject(with: data, options: opt)
-            self.init(jsonObject: object)
-        } catch let aError as NSError {
-            if error != nil {
-                error?.pointee = aError
-            }
-            self.init(jsonObject: NSNull())
-        }
+    public init(data: Data, options opt: JSONSerialization.ReadingOptions = []) throws {
+        let object: Any = try JSONSerialization.jsonObject(with: data, options: opt)
+        self.init(jsonObject: object)
     }
 
     /**
@@ -89,7 +82,11 @@ public struct JSON {
         case let object as [String: JSON] where object.count > 0:
             self.init(dictionary: object)
         case let object as Data:
-            self.init(data: object)
+            do {
+                try self.init(data: object)
+            } catch {
+                self.init(jsonObject: NSNull())
+            }
         default:
             self.init(jsonObject: object)
         }
@@ -117,7 +114,7 @@ public struct JSON {
     @available(*, deprecated: 3.2, message: "Use instead `init(parseJSON: )`")
     public static func parse(_ json: String) -> JSON {
         return json.data(using: String.Encoding.utf8)
-            .flatMap{ JSON(data: $0) } ?? JSON(NSNull())
+            .flatMap{ try? JSON(data: $0) } ?? JSON(NSNull())
     }
 
     /**

--- a/Tests/SwiftyJSONTests/BaseTests.swift
+++ b/Tests/SwiftyJSONTests/BaseTests.swift
@@ -43,7 +43,10 @@ class BaseTests: XCTestCase {
     }
     
     func testInit() {
-        let json0 = JSON(data:self.testData)
+        guard let json0 = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
         XCTAssertEqual(json0.array!.count, 3)
         XCTAssertEqual(JSON("123").description, "123")
         XCTAssertEqual(JSON(["1":"2"])["1"].string!, "2")
@@ -76,7 +79,10 @@ class BaseTests: XCTestCase {
     }
     
     func testJSONDoesProduceValidWithCorrectKeyPath() {
-        let json = JSON(data:self.testData)
+        guard let json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
         
         let tweets = json
         let tweets_array = json.array
@@ -225,7 +231,10 @@ class BaseTests: XCTestCase {
     }
     
     func testErrorHandle() {
-        let json = JSON(data:self.testData)
+        guard let json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
         if let _ = json["wrong-type"].string {
             XCTFail("Should not run into here")
         } else {
@@ -245,11 +254,14 @@ class BaseTests: XCTestCase {
     }
     
     func testReturnObject() {
-        let json = JSON(data:self.testData)
+        guard let json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
         XCTAssertNotNil(json.object)
     }
         
-    func testNumberCompare(){
+    func testNumberCompare() {
         XCTAssertEqual(NSNumber(value: 888332), NSNumber(value:888332))
         XCTAssertNotEqual(NSNumber(value: 888332.1), NSNumber(value:888332))
         XCTAssertLessThan(NSNumber(value: 888332).doubleValue, NSNumber(value:888332.1).doubleValue)
@@ -260,5 +272,16 @@ class BaseTests: XCTestCase {
         XCTAssertEqual(NSNumber(value: true), NSNumber(value:true))
     }
     
-
+    func testErrorThrowing() {
+        let invalidJson = "{\"foo\": 300]"  // deliberately incorrect JSON
+        let invalidData = invalidJson.data(using: .utf8)!
+        
+        do {
+            let _ = try JSON(data: invalidData)
+            XCTFail("Should have thrown error; we should not have gotten here")
+        } catch {
+            // everything is OK
+        }
+    }
+    
 }

--- a/Tests/SwiftyJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftyJSONTests/PerformanceTests.swift
@@ -45,14 +45,20 @@ class PerformanceTests: XCTestCase {
     func testInitPerformance() {
         self.measure() {
             for _ in 1...100 {
-                let json = JSON(data:self.testData)
+                guard let json = try? JSON(data: self.testData) else {
+                    XCTFail("Unable to parse testData")
+                    return
+                }
                 XCTAssertTrue(json != JSON.null)
             }
         }
     }
     
     func testObjectMethodPerformance() {
-        let json = JSON(data:self.testData)
+        guard let json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
         self.measure() {
             for _ in 1...100 {
                 let object:Any? = json.object
@@ -62,7 +68,10 @@ class PerformanceTests: XCTestCase {
     }
 
     func testArrayMethodPerformance() {
-        let json = JSON(data:self.testData)
+        guard let json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
         self.measure() {
             for _ in 1...100 {
                 autoreleasepool{
@@ -75,7 +84,11 @@ class PerformanceTests: XCTestCase {
     }
     
     func testDictionaryMethodPerformance() {
-        let json = JSON(data:testData)[0]
+        guard let json = try? JSON(data: self.testData)[0] else {
+            XCTFail("Unable to parse testData")
+            return
+        }
+
         self.measure() {
             for _ in 1...100 {
                 autoreleasepool{
@@ -88,7 +101,10 @@ class PerformanceTests: XCTestCase {
     }
     
     func testRawStringMethodPerformance() {
-        let json = JSON(data:testData)
+        guard let json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
         self.measure() {
             for _ in 1...100 {
                 autoreleasepool{

--- a/Tests/SwiftyJSONTests/SequenceTypeTests.swift
+++ b/Tests/SwiftyJSONTests/SequenceTypeTests.swift
@@ -29,7 +29,10 @@ class SequenceTypeTests: XCTestCase {
     func testJSONFile() {
         if let file = Bundle(for:BaseTests.self).path(forResource: "Tests", ofType: "json") {
             let testData = try? Data(contentsOf: URL(fileURLWithPath: file))
-            let json = JSON(data:testData!)
+            guard let json = try? JSON(data: testData!) else {
+                XCTFail("Unable to parse the data")
+                return
+            }
             for (index, sub) in json {
                 switch (index as NSString).integerValue {
                 case 0:


### PR DESCRIPTION
I do not anticipate your accepting of this pull request because it is a non-backward compatible change, something that you might understandably be reluctant to do in an interim release. But it might be something for you to consider for your next major release.

In my opinion, the error handling in `init(data:options:error:)` is remarkably unswifty. You should not have `NSErrorPointer` parameter, because naive implementations will fail to capture the error correctly (see [this Stack Overflow question](http://stackoverflow.com/a/41421533/1271826)).

Instead, this initializer should just be changed to `throw` errors. This code makes that change.

---

My original release notes are below:

---

The problem is that when users call `let json = JSON(data: data)`, they are not informed of the error, relying on the presence of `NSNull` value. That sort of use of non-standard sentinel value is discouraged. And the reliance of the `NSErrorPointer` is a pattern that pre-dates Swift 2 (and was intended for interacting with Objective-C API, not to be adopted within a Swift API itself). Bottom line, the error handling in  `init(data:options:error:)` was distinctly unswifty. This attempts to remedy that.

1. Change init(data:options:) to throw errors, removing the `NSErrorPointer` reference.

2. Changed existing code that called `init(data:)` to reflect this error throwing behavior.

3. Also changed default reading options to be `[]` rather than `.allowFragments`, so that it's more consistent with standard `JSONSerialization` behavior. Also, I want to stop the perpetuation of the use of `.allowFragments` as a matter of standard practice, because generally if you have a fragment of JSON, you really want to know about that error.

4. Added unit test to demonstrate error catching.