### PR TITLE
This is to fix issue #786 - conversion of string/number/bool is

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -36,7 +36,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let file = Bundle.main.path(forResource: "SwiftyJSONTests", ofType: "json") {
             do {
                 let data = try Data(contentsOf: URL(fileURLWithPath: file))
-                let json = JSON(data: data)
+                let json = try JSON(data: data)
                 viewController.json = json
             } catch {
                 viewController.json = JSON.null

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -807,8 +807,7 @@ extension JSON { // : Swift.Bool
             case .number:
                 return self.rawNumber.boolValue
             case .string:
-                return ["true", "y", "t", "yes"].contains() { (truthyString) in
-                return ["true", "y", "t"].contains { (truthyString) in
+                return ["true", "y", "t", "yes"].contains { (truthyString) in
                     return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
                 }
             default:

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -852,12 +852,31 @@ extension JSON {
 
 extension JSON { // : Swift.Bool
 
+    //Non-Optional bool
+    public var boolValue: Bool {
+        get {
+              if let v = self.bool {
+                return v
+              }
+              return false
+        }
+        set {
+            self.object = newValue
+        }
+    }
+
     //Optional bool
     public var bool: Bool? {
         get {
             switch self.type {
             case .bool:
                 return self.rawBool
+            case .number:
+                return self.rawNumber.boolValue
+            case .string:
+                return ["true", "y", "t", "yes"].contains() { (truthyString) in
+                    return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
+                }
             default:
                 return nil
             }
@@ -870,39 +889,35 @@ extension JSON { // : Swift.Bool
             }
         }
     }
-
-    //Non-optional bool
-    public var boolValue: Bool {
-        get {
-            switch self.type {
-            case .bool:
-                return self.rawBool
-            case .number:
-                return self.rawNumber.boolValue
-            case .string:
-                return ["true", "y", "t"].contains() { (truthyString) in
-                    return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
-                }
-            default:
-                return false
-            }
-        }
-        set {
-            self.object = newValue
-        }
-    }
 }
 
 // MARK: - String
 
 extension JSON {
 
+    //Non-optional string
+    public var stringValue: String {
+        get {
+            if let v = self.string {
+              return v
+            }
+            return ""
+        }
+        set {
+            self.object = NSString(string:newValue)
+        }
+    }
+
     //Optional string
     public var string: String? {
         get {
             switch self.type {
             case .string:
-                return self.object as? String
+                return self.object as? String ?? ""
+            case .number:
+                return self.rawNumber.stringValue
+            case .bool:
+                return (self.object as? Bool).map { String($0) } ?? ""
             default:
                 return nil
             }
@@ -915,36 +930,36 @@ extension JSON {
             }
         }
     }
-
-    //Non-optional string
-    public var stringValue: String {
-        get {
-            switch self.type {
-            case .string:
-                return self.object as? String ?? ""
-            case .number:
-                return self.rawNumber.stringValue
-            case .bool:
-                return (self.object as? Bool).map { String($0) } ?? ""
-            default:
-                return ""
-            }
-        }
-        set {
-            self.object = NSString(string:newValue)
-        }
-    }
 }
 
 // MARK: - Number
 extension JSON {
 
+    //Non-optional number
+    public var numberValue: NSNumber {
+        get {
+            if let v = self.number {
+              return v
+            }
+            return NSNumber(value: 0.0)
+        }
+        set {
+            self.object = newValue
+        }
+    }
+
     //Optional number
     public var number: NSNumber? {
         get {
             switch self.type {
+            case .string:
+                let decimal = NSDecimalNumber(string: self.object as? String)
+                if decimal == NSDecimalNumber.notANumber {  // indicates parse error
+                    return nil
+                }
+                return decimal
             case .number:
-                return self.rawNumber
+                return self.object as? NSNumber ?? NSNumber(value: 0)
             case .bool:
                 return NSNumber(value: self.rawBool ? 1 : 0)
             default:
@@ -953,29 +968,6 @@ extension JSON {
         }
         set {
             self.object = newValue ?? NSNull()
-        }
-    }
-
-    //Non-optional number
-    public var numberValue: NSNumber {
-        get {
-            switch self.type {
-            case .string:
-                let decimal = NSDecimalNumber(string: self.object as? String)
-                if decimal == NSDecimalNumber.notANumber {  // indicates parse error
-                    return NSDecimalNumber.zero
-                }
-                return decimal
-            case .number:
-                return self.object as? NSNumber ?? NSNumber(value: 0)
-            case .bool:
-                return NSNumber(value: self.rawBool ? 1 : 0)
-            default:
-                return NSNumber(value: 0.0)
-            }
-        }
-        set {
-            self.object = newValue
         }
     }
 }

--- a/Tests/SwiftyJSONTests/NumberTests.swift
+++ b/Tests/SwiftyJSONTests/NumberTests.swift
@@ -24,7 +24,7 @@ import XCTest
 import SwiftyJSON
 
 class NumberTests: XCTestCase {
-
+    
     func testNumber() {
         //getter
         var json = JSON(NSNumber(value: 9876543210.123456789))
@@ -33,8 +33,12 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(json.stringValue, "9876543210.123457")
         
         json.string = "1000000000000000000000000000.1"
-        XCTAssertNil(json.number)
+        XCTAssertEqual(json.number!.description, "1000000000000000000000000000.1")
         XCTAssertEqual(json.numberValue.description, "1000000000000000000000000000.1")
+        
+        json.string = "NotANumber"
+        XCTAssertNil(json.number)
+        XCTAssertEqual(json.numberValue, NSNumber(value: 0.0))
 
         json.string = "1e+27"
         XCTAssertEqual(json.numberValue.description, "1000000000000000000000000000")
@@ -59,6 +63,15 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(json.boolValue, true)
         XCTAssertEqual(json.numberValue, true as NSNumber)
         XCTAssertEqual(json.stringValue, "true")
+        
+        json = JSON("yes")
+        XCTAssertEqual(json.boolValue, true)
+        
+        json = JSON("t")
+        XCTAssertEqual(json.boolValue, true)
+        
+        json = JSON("y")
+        XCTAssertEqual(json.boolValue, true)
         
         json.bool = false
         XCTAssertEqual(json.bool!, false)

--- a/Tests/SwiftyJSONTests/NumberTests.swift
+++ b/Tests/SwiftyJSONTests/NumberTests.swift
@@ -35,7 +35,7 @@ class NumberTests: XCTestCase {
         json.string = "1000000000000000000000000000.1"
         XCTAssertEqual(json.number!.description, "1000000000000000000000000000.1")
         XCTAssertEqual(json.numberValue.description, "1000000000000000000000000000.1")
-        
+
         json.string = "NotANumber"
         XCTAssertNil(json.number)
         XCTAssertEqual(json.numberValue, NSNumber(value: 0.0))
@@ -63,20 +63,16 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(json.boolValue, true)
         XCTAssertEqual(json.numberValue, true as NSNumber)
         XCTAssertEqual(json.stringValue, "true")
-<<<<<<< HEAD
-        
+
         json = JSON("yes")
         XCTAssertEqual(json.boolValue, true)
-        
+
         json = JSON("t")
         XCTAssertEqual(json.boolValue, true)
-        
+
         json = JSON("y")
         XCTAssertEqual(json.boolValue, true)
-        
-=======
 
->>>>>>> master
         json.bool = false
         XCTAssertEqual(json.bool!, false)
         XCTAssertEqual(json.boolValue, false)

--- a/Tests/SwiftyJSONTests/StringTests.swift
+++ b/Tests/SwiftyJSONTests/StringTests.swift
@@ -60,7 +60,7 @@ class StringTests: XCTestCase {
         let json = JSON("Yes")
         XCTAssertTrue(json.boolValue)
     }
-    
+
     func testBoolWithTrue() {
         let json = JSON("True")
         XCTAssertTrue(json.boolValue)

--- a/Tests/SwiftyJSONTests/StringTests.swift
+++ b/Tests/SwiftyJSONTests/StringTests.swift
@@ -56,6 +56,16 @@ class StringTests: XCTestCase {
         XCTAssertTrue(json.boolValue)
     }
 
+    func testBoolWithYes() {
+        let json = JSON("Yes")
+        XCTAssertTrue(json.boolValue)
+    }
+    
+    func testBoolWithTrue() {
+        let json = JSON("True")
+        XCTAssertTrue(json.boolValue)
+    }
+
     func testUrlPercentEscapes() {
         let emDash = "\\u2014"
         let urlString = "http://examble.com/unencoded" + emDash + "string"


### PR DESCRIPTION
different for optional/non-optional

stringValue now just calls string, and passes back the default "" if
it received nil

numberValue now just calls number, and passes back the default
NSNumber(0.0) if it received nil

boolValue now just calls bool, and passes back the default false
if it received nil

Added support for "yes" and "true" in bool conversion since "y" and "t"
were accepted.

Updated Number and String tests to match