### PR TITLE
RawTests.testNestedJSON() added

### DIFF
--- a/Tests/SwiftyJSONTests/RawTests.swift
+++ b/Tests/SwiftyJSONTests/RawTests.swift
@@ -92,4 +92,18 @@ class RawTests: XCTestCase {
         let json: JSON = JSON.null
         XCTAssertEqual(json.rawString(), "null")
     }
+	
+	func testNestedJSON() {
+		let inner: JSON = ["name": "john doe"]
+		let json: JSON = ["level": 1337, "user": inner]
+		let data: Data?
+		do {
+			data = try json.rawData()
+		} catch _ {
+			data = nil
+		}
+		let string = json.rawString()
+		XCTAssertNotNil(data)
+		XCTAssertNotNil(string)
+	}
 }

--- a/Tests/SwiftyJSONTests/RawTests.swift
+++ b/Tests/SwiftyJSONTests/RawTests.swift
@@ -92,18 +92,18 @@ class RawTests: XCTestCase {
         let json: JSON = JSON.null
         XCTAssertEqual(json.rawString(), "null")
     }
-	
-	func testNestedJSON() {
-		let inner: JSON = ["name": "john doe"]
-		let json: JSON = ["level": 1337, "user": inner]
-		let data: Data?
-		do {
-			data = try json.rawData()
-		} catch _ {
-			data = nil
-		}
-		let string = json.rawString()
-		XCTAssertNotNil(data)
-		XCTAssertNotNil(string)
-	}
+
+    func testNestedJSON() {
+        let inner: JSON = ["name": "john doe"]
+        let json: JSON = ["level": 1337, "user": inner]
+        let data: Data?
+        do {
+            data = try json.rawData()
+        } catch _ {
+            data = nil
+        }
+        let string = json.rawString()
+        XCTAssertNotNil(data)
+        XCTAssertNotNil(string)
+    }
 }


### PR DESCRIPTION
This PR strengthens the tests around the JSON.rawData() function.

The https://github.com/IBM-Swift/SwiftyJSON fork has problems serializing nested json, it returns nil. 

The SwiftyJSON/SwiftyJSON has no problems serializing nested json. It works as it should.


I have added a unittest that hopefully can cause the problem to be fixed in the IBM-Swift/SwiftyJSON fork.


# Proof of concept

This was my original proof of concept code for recreating the problem.

	func asJson() -> JSON {
		let user: JSON = [
			"name": "John Doe"
		]
		return [
			"alarmLevel": 123,
			"user": user
		]
	}
	
	func main() {
		let json = asJson()
		let s = json.rawString() ?? "ERROR"
		print(s)
	}


Output when using SwiftyJSON/SwiftyJSON

	{
	  "alarmLevel" : 123,
	  "user" : {
	    "name" : "John Doe"
	  }
	}

Output when using IBM-Swift/SwiftyJSON

    ERROR

