### PR TITLE
optional number getter fix

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -876,6 +876,12 @@ extension JSON {
     public var number: NSNumber? {
         get {
             switch self.type {
+            case .string:
+                let decimal = NSDecimalNumber(string: self.object as? String)
+                if decimal == NSDecimalNumber.notANumber {  // indicates parse error
+                    return nil
+                }
+                return decimal
             case .number:
                 return self.rawNumber
             case .bool:


### PR DESCRIPTION
`case .string` is missed for optional `number` getter. I just put the same code from non-optional `number` getter, except that if NSDecimalNumber fails to parse string - it returns nil