### PR TITLE
call can throw but is not marked with try

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -36,7 +36,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let file = Bundle.main.path(forResource: "SwiftyJSONTests", ofType: "json") {
             do {
                 let data = try Data(contentsOf: URL(fileURLWithPath: file))
-                let json = JSON(data: data)
+                let json = try JSON(data: data)
                 viewController.json = json
             } catch {
                 viewController.json = JSON.null


### PR DESCRIPTION
Hello,
I See JSON(data: data) has throws exception, so add 'try' in front, the error "call can throw but is not marked with try" can fixed.

public init(data: Data, options opt: JSONSerialization.ReadingOptions = []) throws {
}

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
 - What code was refactored / updated to support this change?
 - What issues are related to this PR? Or why was this change introduced?

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?