### PR TITLE
[4.0.0] Error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,18 @@ for (index,subJson):(String, JSON) in json {
 
 #### Error
 
+##### SwiftyJSON 4.x
+
+SwiftyJSON 4.x introduces an enum type called `SwiftyJSONError`, which includes `unsupportedType`, `indexOutOfBounds`, `elementTooDeep`, `wrongType`, `notExist` and `invalidJSON`, at the same time, `ErrorDomain` are being replaced by `SwiftyJSONError.errorDomain`. 
+Note: Those old error types are deprecated in SwiftyJSON 4.x and will be removed in the future release.
+
+##### SwiftyJSON 3.x
+
 Use a subscript to get/set a value in an Array or Dictionary
 
 If the JSON is:
 *  an array, the app may crash with "index out-of-bounds."
-*  a dictionary, it will be assigned `nil` without a reason.
+*  a dictionary, it will be assigned to `nil` without a reason.
 *  not an array or a dictionary, the app may crash with an "unrecognised selector" exception.
 
 This will never happen in SwiftyJSON.

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -266,7 +266,7 @@ public struct JSON {
                 self.rawDictionary = dictionary
             default:
                 _type = .unknown
-                _error = .unsupportedType
+                _error = SwiftyJSONError.unsupportedType
             }
         }
     }

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -55,7 +55,7 @@ extension SwiftyJSONError: CustomNSError {
 
     public var errorCode: Int { return self.rawValue }
 
-    public var errorUserInfo: [String : String] {
+    public var errorUserInfo: [String : Any] {
         switch self {
         case .unsupportedType:
             return [NSLocalizedDescriptionKey: "It is a unsupported type."]

--- a/Tests/SwiftyJSONTests/BaseTests.swift
+++ b/Tests/SwiftyJSONTests/BaseTests.swift
@@ -239,18 +239,18 @@ class BaseTests: XCTestCase {
         if json["wrong-type"].string != nil {
             XCTFail("Should not run into here")
         } else {
-            XCTAssertEqual(json["wrong-type"].error!.code, SwiftyJSON.ErrorWrongType)
+            XCTAssertEqual(json["wrong-type"].error, SwiftyJSONError.wrongType)
         }
 
         if json[0]["not-exist"].string != nil {
             XCTFail("Should not run into here")
         } else {
-            XCTAssertEqual(json[0]["not-exist"].error!.code, SwiftyJSON.ErrorNotExist)
+            XCTAssertEqual(json[0]["not-exist"].error, SwiftyJSONError.notExist)
         }
 
         let wrongJSON = JSON(NSObject())
         if let error = wrongJSON.error {
-            XCTAssertEqual(error.code, SwiftyJSON.ErrorUnsupportedType)
+            XCTAssertEqual(error, SwiftyJSONError.unsupportedType)
         }
     }
 

--- a/Tests/SwiftyJSONTests/MergeTests.swift
+++ b/Tests/SwiftyJSONTests/MergeTests.swift
@@ -33,13 +33,11 @@ class JSONTests: XCTestCase {
         do {
             _ = try A.merged(with: B)
             XCTFail()
-        } catch (let error) {
-            let error = error as NSError
-            XCTAssertEqual(error.code, ErrorWrongType)
-            XCTAssertEqual(error.domain, ErrorDomain)
-            XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey] as! String,
-                           "Couldn't merge, because the JSONs differ in type on top level.")
-        }
+        } catch let error as SwiftyJSONError {
+            XCTAssertEqual(error.errorCode, SwiftyJSONError.wrongType.rawValue)
+            XCTAssertEqual(type(of: error).errorDomain, SwiftyJSONError.errorDomain)
+            XCTAssertEqual(error.errorUserInfo as! [String: String], [NSLocalizedDescriptionKey: "Couldn't merge, because the JSONs differ in type on top level."])
+        } catch _ {}
     }
 
     func testPrimitiveType() {

--- a/Tests/SwiftyJSONTests/RawTests.swift
+++ b/Tests/SwiftyJSONTests/RawTests.swift
@@ -40,9 +40,9 @@ class RawTests: XCTestCase {
         let json: JSON = "...<nonsense>xyz</nonsense>"
         do {
             _ = try json.rawData()
-        } catch let error as NSError {
-            XCTAssertEqual(error.code, ErrorInvalidJSON)
-        }
+        } catch let error as SwiftyJSONError {
+            XCTAssertEqual(error, SwiftyJSONError.invalidJSON)
+        } catch _ {}
     }
 
     func testArray() {

--- a/Tests/SwiftyJSONTests/SubscriptTests.swift
+++ b/Tests/SwiftyJSONTests/SubscriptTests.swift
@@ -180,37 +180,37 @@ class SubscriptTests: XCTestCase {
     func testOutOfBounds() {
         let json: JSON = JSON ([[NSNumber(value:1), NSNumber(value:2.123456), NSNumber(value:123456789)], ["aa", "bbb", "cccc"], [true, "766", NSNull(), 655231.9823]] as NSArray)
         XCTAssertEqual(json[9], JSON.null)
-        XCTAssertEqual(json[-2].error!.code, ErrorIndexOutOfBounds)
-        XCTAssertEqual(json[6].error!.code, ErrorIndexOutOfBounds)
+        XCTAssertEqual(json[-2].error, SwiftyJSONError.indexOutOfBounds)
+        XCTAssertEqual(json[6].error, SwiftyJSONError.indexOutOfBounds)
         XCTAssertEqual(json[9][8], JSON.null)
-        XCTAssertEqual(json[8][7].error!.code, ErrorIndexOutOfBounds)
-        XCTAssertEqual(json[8, 7].error!.code, ErrorIndexOutOfBounds)
-        XCTAssertEqual(json[999].error!.code, ErrorIndexOutOfBounds)
+        XCTAssertEqual(json[8][7].error, SwiftyJSONError.indexOutOfBounds)
+        XCTAssertEqual(json[8, 7].error, SwiftyJSONError.indexOutOfBounds)
+        XCTAssertEqual(json[999].error, SwiftyJSONError.indexOutOfBounds)
     }
 
     func testErrorWrongType() {
         let json = JSON(12345)
         XCTAssertEqual(json[9], JSON.null)
-        XCTAssertEqual(json[9].error!.code, ErrorWrongType)
-        XCTAssertEqual(json[8][7].error!.code, ErrorWrongType)
+        XCTAssertEqual(json[9].error, SwiftyJSONError.wrongType)
+        XCTAssertEqual(json[8][7].error, SwiftyJSONError.wrongType)
         XCTAssertEqual(json["name"], JSON.null)
-        XCTAssertEqual(json["name"].error!.code, ErrorWrongType)
-        XCTAssertEqual(json[0]["name"].error!.code, ErrorWrongType)
-        XCTAssertEqual(json["type"]["name"].error!.code, ErrorWrongType)
-        XCTAssertEqual(json["name"][99].error!.code, ErrorWrongType)
-        XCTAssertEqual(json[1, "Value"].error!.code, ErrorWrongType)
-        XCTAssertEqual(json[1, 2, "Value"].error!.code, ErrorWrongType)
-        XCTAssertEqual(json[[1, 2, "Value"]].error!.code, ErrorWrongType)
+        XCTAssertEqual(json["name"].error, SwiftyJSONError.wrongType)
+        XCTAssertEqual(json[0]["name"].error, SwiftyJSONError.wrongType)
+        XCTAssertEqual(json["type"]["name"].error, SwiftyJSONError.wrongType)
+        XCTAssertEqual(json["name"][99].error, SwiftyJSONError.wrongType)
+        XCTAssertEqual(json[1, "Value"].error, SwiftyJSONError.wrongType)
+        XCTAssertEqual(json[1, 2, "Value"].error, SwiftyJSONError.wrongType)
+        XCTAssertEqual(json[[1, 2, "Value"]].error, SwiftyJSONError.wrongType)
     }
 
     func testErrorNotExist() {
         let json: JSON = ["name": "NAME", "age": 15]
         XCTAssertEqual(json["Type"], JSON.null)
-        XCTAssertEqual(json["Type"].error!.code, ErrorNotExist)
-        XCTAssertEqual(json["Type"][1].error!.code, ErrorNotExist)
-        XCTAssertEqual(json["Type", 1].error!.code, ErrorNotExist)
-        XCTAssertEqual(json["Type"]["Value"].error!.code, ErrorNotExist)
-        XCTAssertEqual(json["Type", "Value"].error!.code, ErrorNotExist)
+        XCTAssertEqual(json["Type"].error, SwiftyJSONError.notExist)
+        XCTAssertEqual(json["Type"][1].error, SwiftyJSONError.notExist)
+        XCTAssertEqual(json["Type", 1].error, SwiftyJSONError.notExist)
+        XCTAssertEqual(json["Type"]["Value"].error, SwiftyJSONError.notExist)
+        XCTAssertEqual(json["Type", "Value"].error, SwiftyJSONError.notExist)
     }
 
     func testMultilevelGetter() {


### PR DESCRIPTION
Continues the work of #774 , make SwiftyJSON's error handling moving from NSError to Swift.Error.
This PR introudces a new `SwiftyJSONError` type and deprecated those old NSError types.

Here is the migration guide:

Old 3.X | New 4.X
-----|-----
ErrorDomain | SwiftyJSONError.errorDomain
ErrorUnsupportedType | SwiftyJSONError.unsupportedType
ErrorIndexOutOfBounds | SwiftyJSONError.indexOutOfBounds
ErrorWrongType | SwiftyJSONError.wrongType
ErrorNotExist | SwiftyJSONError.notExist
ErrorInvalidJSON | SwiftyJSONError.invalidJSON


Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [x] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?