### PR TITLE
Change NSNumber extension’s access modifier to fileprivate

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -1362,7 +1362,7 @@ private let falseObjCType = String(cString: falseNumber.objCType)
 // MARK: - NSNumber: Comparable
 
 extension NSNumber {
-    var isBool: Bool {
+    fileprivate var isBool: Bool {
         let objCType = String(cString: self.objCType)
         if (self.compare(trueNumber) == .orderedSame && objCType == trueObjCType) || (self.compare(falseNumber) == .orderedSame && objCType == falseObjCType) {
             return true


### PR DESCRIPTION
NSNumber's isBool extension is not designated to be accessed as part of SwiftyJSON.
Will fix #812 