### PR TITLE
Fix a potential crash issue by checking whether index is out of json array’s bound.

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -424,7 +424,7 @@ extension JSON {
         }
         set {
             if self.type == .array {
-                if self.rawArray.count > index && newValue.error == nil {
+                if index >= 0 && index < self.rawArray.count && newValue.error == nil {
                     self.rawArray[index] = newValue.object
                 }
             }

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -58,7 +58,7 @@ extension SwiftyJSONError: CustomNSError {
     public var errorUserInfo: [String : Any] {
         switch self {
         case .unsupportedType:
-            return [NSLocalizedDescriptionKey: "It is a unsupported type."]
+            return [NSLocalizedDescriptionKey: "It is an unsupported type."]
         case .indexOutOfBounds:
             return [NSLocalizedDescriptionKey: "Array Index is out of bounds."]
         case .wrongType:
@@ -407,7 +407,7 @@ extension String: JSONSubscriptType {
 
 extension JSON {
 
-    /// If `type` is `.Array`, return json whose object is `array[index]`, otherwise return null json with error.
+    /// If `type` is `.array`, return json whose object is `array[index]`, otherwise return null json with error.
     fileprivate subscript(index index: Int) -> JSON {
         get {
             if self.type != .array {

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -217,10 +217,10 @@ public struct JSON {
     fileprivate var rawNumber: NSNumber = 0
     fileprivate var rawNull: NSNull = NSNull()
     fileprivate var rawBool: Bool = false
-    
+
     /// JSON type, fileprivate setter
     public fileprivate(set) var type: Type = .null
-    
+
     /// Error in JSON, fileprivate setter
     public fileprivate(set) var error: SwiftyJSONError?
 

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -217,10 +217,12 @@ public struct JSON {
     fileprivate var rawNumber: NSNumber = 0
     fileprivate var rawNull: NSNull = NSNull()
     fileprivate var rawBool: Bool = false
-    /// Private type
-    fileprivate var _type: Type = .null
-    /// Private error
-    fileprivate var _error: SwiftyJSONError?
+    
+    /// JSON type, fileprivate setter
+    public fileprivate(set) var type: Type = .null
+    
+    /// Error in JSON, fileprivate setter
+    public fileprivate(set) var error: SwiftyJSONError?
 
     /// Object in JSON
     public var object: Any {
@@ -241,41 +243,35 @@ public struct JSON {
             }
         }
         set {
-            _error = nil
+            error = nil
             switch unwrap(newValue) {
             case let number as NSNumber:
                 if number.isBool {
-                    _type = .bool
+                    type = .bool
                     self.rawBool = number.boolValue
                 } else {
-                    _type = .number
+                    type = .number
                     self.rawNumber = number
                 }
             case let string as String:
-                _type = .string
+                type = .string
                 self.rawString = string
             case _ as NSNull:
-                _type = .null
+                type = .null
             case nil:
-                _type = .null
+                type = .null
             case let array as [Any]:
-                _type = .array
+                type = .array
                 self.rawArray = array
             case let dictionary as [String : Any]:
-                _type = .dictionary
+                type = .dictionary
                 self.rawDictionary = dictionary
             default:
-                _type = .unknown
-                _error = SwiftyJSONError.unsupportedType
+                type = .unknown
+                error = SwiftyJSONError.unsupportedType
             }
         }
     }
-
-    /// JSON type
-    public var type: Type { return _type }
-
-    /// Error in JSON
-    public var error: SwiftyJSONError? { return _error }
 
     /// The static null JSON
     @available(*, unavailable, renamed:"null")
@@ -416,13 +412,13 @@ extension JSON {
         get {
             if self.type != .array {
                 var r = JSON.null
-                r._error = self._error ?? SwiftyJSONError.wrongType
+                r.error = self.error ?? SwiftyJSONError.wrongType
                 return r
             } else if index >= 0 && index < self.rawArray.count {
                 return JSON(self.rawArray[index])
             } else {
                 var r = JSON.null
-                r._error = SwiftyJSONError.indexOutOfBounds
+                r.error = SwiftyJSONError.indexOutOfBounds
                 return r
             }
         }
@@ -443,10 +439,10 @@ extension JSON {
                 if let o = self.rawDictionary[key] {
                     r = JSON(o)
                 } else {
-                    r._error = SwiftyJSONError.notExist
+                    r.error = SwiftyJSONError.notExist
                 }
             } else {
-                r._error = self._error ?? SwiftyJSONError.wrongType
+                r.error = self.error ?? SwiftyJSONError.wrongType
             }
             return r
         }


### PR DESCRIPTION
The following code will cause a crash. Of course, usually user would not intendedly pass a negative index when accessing a json object of array. However, if the index was calculated by other part of code, it could be negative. What this PR did is just to add the logic of checking index >=0 within subscript(index:) method.

```
var json = JSON(parseJSON: "[1.0, 2.0]")
var index = -1
json[index] = 2.0
```