### PR TITLE
Fix a potential crash issue by checking whether index is out of json array’s bound.

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -58,7 +58,7 @@ extension SwiftyJSONError: CustomNSError {
     public var errorUserInfo: [String : Any] {
         switch self {
         case .unsupportedType:
-            return [NSLocalizedDescriptionKey: "It is a unsupported type."]
+            return [NSLocalizedDescriptionKey: "It is an unsupported type."]
         case .indexOutOfBounds:
             return [NSLocalizedDescriptionKey: "Array Index is out of bounds."]
         case .wrongType:
@@ -411,7 +411,7 @@ extension String: JSONSubscriptType {
 
 extension JSON {
 
-    /// If `type` is `.Array`, return json whose object is `array[index]`, otherwise return null json with error.
+    /// If `type` is `.array`, return json whose object is `array[index]`, otherwise return null json with error.
     fileprivate subscript(index index: Int) -> JSON {
         get {
             if self.type != .array {
@@ -435,7 +435,7 @@ extension JSON {
         }
     }
 
-    /// If `type` is `.Dictionary`, return json whose object is `dictionary[key]` , otherwise return null json with error.
+    /// If `type` is `.dictionary`, return json whose object is `dictionary[key]` , otherwise return null json with error.
     fileprivate subscript(key key: String) -> JSON {
         get {
             var r = JSON.null

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -418,7 +418,7 @@ extension JSON {
                 var r = JSON.null
                 r._error = self._error ?? SwiftyJSONError.wrongType
                 return r
-            } else if index >= 0 && index < self.rawArray.count {
+            } else if self.rawArray.indices.contains(index) {
                 return JSON(self.rawArray[index])
             } else {
                 var r = JSON.null
@@ -427,10 +427,10 @@ extension JSON {
             }
         }
         set {
-            if self.type == .array {
-                if self.rawArray.count > index && newValue.error == nil {
-                    self.rawArray[index] = newValue.object
-                }
+            if self.type == .array &&
+                self.rawArray.indices.contains(index) &&
+                newValue.error == nil {
+                self.rawArray[index] = newValue.object
             }
         }
     }


### PR DESCRIPTION
The following code will cause a crash. Of course, usually user would not intendedly pass a negative index when accessing a json object of array. However, if the index was calculated by other part of code, it could be negative. What this PR did is just to add the logic of checking index >=0 within subscript(index:) method.

```
var json = JSON(parseJSON: "[1.0, 2.0]")
var index = -1
json[index] = 2.0
```