### PR TITLE
"1" and "yes" for the bool extension

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -843,7 +843,7 @@ extension JSON { // : Swift.Bool
             case .number:
                 return self.rawNumber.boolValue
             case .string:
-                return ["true", "y", "t"].contains { (truthyString) in
+                return ["true", "y", "t", "1", "yes"].contains { (truthyString) in
                     return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
                 }
             default:


### PR DESCRIPTION
Added possible value "1" and "yes" for the bool extension

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
Ans: .boolValue property behaviour changed, when you get "1" or "yes" from server side,
now you will get true value in above cases 

 - What code was refactored / updated to support this change?
Ans: Changes SwiftyJSON.swift  - line 846

 - What issues are related to this PR? Or why was this change introduced?
Ans: We were not getting right bool value when retrieving "1" or "yes" from server side,
we were always getting false in above cases.

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?