### PR TITLE
Generic materialize function with throwable behaviour for throwable initializers

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -47,6 +47,7 @@ public enum SwiftyJSONError: Int, Swift.Error {
     case wrongType = 901
     case notExist = 500
     case invalidJSON = 490
+    case someParsingError = 1
 }
 
 extension SwiftyJSONError: CustomNSError {
@@ -69,6 +70,8 @@ extension SwiftyJSONError: CustomNSError {
             return [NSLocalizedDescriptionKey: "JSON is invalid."]
         case .elementTooDeep:
             return [NSLocalizedDescriptionKey: "Element too deep. Increase maxObjectDepth and make sure there is no reference loop."]
+        case .someParsingError:
+            return [NSLocalizedDescriptionKey: "Some parsing error"]
         }
     }
 }
@@ -1450,4 +1453,94 @@ public enum writingOptionsKeys {
 	case castNilToNSNull
 	case maxObjextDepth
 	case encoding
+}
+
+// MARK: -
+
+public protocol JSONMaterializableType {
+    
+    static var implementation: (JSON, () -> Error) throws -> Self { get }
+}
+
+extension Bool: JSONMaterializableType {
+    
+    public static var implementation: (JSON, () -> Error) throws -> Bool {
+        return { (json: JSON, factory: () -> Error) throws -> Bool in
+            if case .some(let bool) = json.bool {
+                return bool
+            }
+            throw factory()
+        }
+    }
+}
+
+extension Double: JSONMaterializableType {
+    
+    public static var implementation: (JSON, () -> Error) throws -> Double {
+        return { (json: JSON, factory: () -> Error) throws -> Double in
+            if case .some(let double) = json.double {
+                return double
+            }
+            throw factory()
+        }
+    }
+}
+
+extension Int: JSONMaterializableType {
+    
+    public static var implementation: (JSON, () -> Error) throws -> Int {
+        return { (json: JSON, factory: () -> Error) throws -> Int in
+            if case .some(let int) = json.int {
+                return int
+            }
+            throw factory()
+        }
+    }
+}
+
+extension String: JSONMaterializableType {
+    
+    public static var implementation: (JSON, () -> Error) throws -> String {
+        return { (json: JSON, factory: () -> Error) throws -> String in
+            if case .some(let string) = json.string {
+                return string
+            }
+            throw factory()
+        }
+    }
+}
+
+// might include file/line where the parsing error occured
+private func factoryError(file: String, line: Int) -> () -> Error {
+    return { SwiftyJSONError.someParsingError }
+}
+
+public extension JSON {
+    
+    func materialize<T>(file: String = #file, line: Int = #line) -> T? where T: JSONMaterializableType {
+        return try? T.implementation(self, factoryError(file: file, line: line))
+    }
+    
+    func materialize<T>(file: String = #file, line: Int = #line) throws -> [T] where T: JSONMaterializableType {
+        switch array {
+        case .some(let array):
+            return try array.map({ try T.implementation($0, factoryError(file: file, line: line)) })
+        default:
+            throw factoryError(file: file, line: line)()
+        }
+    }
+    
+    func materialize<T>(file: String = #file, line: Int = #line) throws -> T where T: JSONMaterializableType {
+        return try T.implementation(self, factoryError(file: file, line: line))
+    }
+    
+    func materialize<T>(file: String = #file, line: Int = #line) throws -> T where T: RawRepresentable, T.RawValue: JSONMaterializableType {
+        let rawValue: T.RawValue = try materialize(file: file, line: line)
+        switch T(rawValue: rawValue) {
+        case .some(let value):
+            return value
+        default:
+            throw factoryError(file: file, line: line)()
+        }
+    }
 }


### PR DESCRIPTION
Lets say I have some struct and some enum

```
enum ValueEnum: Int {
    case first = 1
    case second = 2
}

struct MyStruct {
    let valueBool: Bool?
    let valueDouble: [Double]
    let valueEnum: ValueEnum
    let valueInt: Int
    let valueString: String
}
```
I want to parse the struct from JSON
```
struct MyStruct {
    let valueBool: Bool?
    let valueDouble: [Double]
    let valueEnum: ValueEnum
    let valueInt: Int
    let valueString: String
    
    init(json: JSON) throws {
        // parse
    }
}
```
JSON looks this way
```
let json: JSON = [
    "valueString": "hello",
    "valueDictionary": [
        "valueInt": 100500
    ],
    "valueDouble": [1.1, 2.2, 3.3],
    "valueEnum": 2
]
```
This is an example how I'd parse it in a pure SwiftyJSON way
```
init(json: JSON) throws {
    valueBool = json["valueBool"].bool
    if let valueDouble = json["valueDouble"].array {
        self.valueDouble = try valueDouble
            .map({ (json) -> Double in
                if let double = json.double {
                    return double
                } else {
                    throw SwiftyJSONError.someParsingError
                }
            })
    } else {
        throw SwiftyJSONError.someParsingError
    }
    if let value = json["valueEnum"].int {
        if let valueEnum = ValueEnum(rawValue: value) {
            self.valueEnum = valueEnum
        } else {
            throw SwiftyJSONError.someParsingError
        }
    } else {
        throw SwiftyJSONError.someParsingError
    }
    if let valueInt = json["valueDictionary"]["valueInt"].int {
        self.valueInt = valueInt
    } else {
        throw SwiftyJSONError.someParsingError
    }
    if let valueString = json["valueString"].string {
        self.valueString = valueString
    } else {
        throw SwiftyJSONError.someParsingError
    }
}
```
My pull request allows to do it this way
```
init(json: JSON) throws {
    valueBool = json["valueBool"].materialize()
    valueDouble = try json["valueDouble"].materialize()
    valueEnum = try json["valueEnum"].materialize()
    valueInt = try json["valueDictionary"]["valueInt"].materialize()
    valueString = try json["valueString"].materialize()
}
```
My pull request is just a proposal. Please don't merge it. Lets discuss.
Maybe... I'm missing something and there is already some way to conveniently parse and throw errors.