### PR TITLE
Fixed name in licenses

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -1,4 +1,4 @@
-//  SwiftyJSON.h
+//  AppDelegate.swift
 //
 //  Copyright (c) 2014 - 2016 Pinglin Tang
 //

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -1,4 +1,4 @@
-//  SwiftyJSON.h
+//  ViewController.swift
 //
 //  Copyright (c) 2014 - 2016 Pinglin Tang
 //


### PR DESCRIPTION
The file names in the license of some files were wrong, probably because of copying the license text and forgetting about the name