### PR TITLE
swift dictionary convention

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -55,7 +55,7 @@ extension SwiftyJSONError: CustomNSError {
 
     public var errorCode: Int { return self.rawValue }
 
-    public var errorUserInfo: [String : Any] {
+    public var errorUserInfo: [String: Any] {
         switch self {
         case .unsupportedType:
             return [NSLocalizedDescriptionKey: "It is an unsupported type."]
@@ -220,7 +220,7 @@ public struct JSON {
 
     /// Private object
     fileprivate var rawArray: [Any] = []
-    fileprivate var rawDictionary: [String : Any] = [:]
+    fileprivate var rawDictionary: [String: Any] = [:]
     fileprivate var rawString: String = ""
     fileprivate var rawNumber: NSNumber = 0
     fileprivate var rawNull: NSNull = NSNull()
@@ -271,7 +271,7 @@ public struct JSON {
             case let array as [Any]:
                 type = .array
                 self.rawArray = array
-            case let dictionary as [String : Any]:
+            case let dictionary as [String: Any]:
                 type = .dictionary
                 self.rawDictionary = dictionary
             default:
@@ -294,7 +294,7 @@ private func unwrap(_ object: Any) -> Any {
         return unwrap(json.object)
     case let array as [Any]:
         return array.map(unwrap)
-    case let dictionary as [String : Any]:
+    case let dictionary as [String: Any]:
         var unwrappedDic = dictionary
         for (k, v) in dictionary {
             unwrappedDic[k] = unwrap(v)
@@ -784,8 +784,8 @@ extension JSON {
 
 extension JSON {
 
-    //Optional [String : JSON]
-    public var dictionary: [String : JSON]? {
+    //Optional [String: JSON]
+    public var dictionary: [String: JSON]? {
         if self.type == .dictionary {
             var d = [String: JSON](minimumCapacity: rawDictionary.count)
             for (key, value) in rawDictionary {
@@ -797,14 +797,14 @@ extension JSON {
         }
     }
 
-    //Non-optional [String : JSON]
-    public var dictionaryValue: [String : JSON] {
+    //Non-optional [String: JSON]
+    public var dictionaryValue: [String: JSON] {
         return self.dictionary ?? [:]
     }
 
-    //Optional [String : Any]
+    //Optional [String: Any]
 
-    public var dictionaryObject: [String : Any]? {
+    public var dictionaryObject: [String: Any]? {
         get {
             switch self.type {
             case .dictionary:

--- a/Tests/SwiftyJSONTests/DictionaryTests.swift
+++ b/Tests/SwiftyJSONTests/DictionaryTests.swift
@@ -26,7 +26,7 @@ import SwiftyJSON
 class DictionaryTests: XCTestCase {
 
     func testGetter() {
-        let dictionary = ["number": 9823.212, "name": "NAME", "list": [1234, 4.212], "object": ["sub_number": 877.2323, "sub_name": "sub_name"], "bool": true] as [String : Any]
+        let dictionary = ["number": 9823.212, "name": "NAME", "list": [1234, 4.212], "object": ["sub_number": 877.2323, "sub_name": "sub_name"], "bool": true] as [String: Any]
         let json = JSON(dictionary)
         //dictionary
         XCTAssertEqual((json.dictionary!["number"]! as JSON).double!, 9823.212)
@@ -48,8 +48,8 @@ class DictionaryTests: XCTestCase {
 
     func testSetter() {
         var json: JSON = ["test": "case"]
-        XCTAssertEqual(json.dictionaryObject! as! [String : String], ["test": "case"])
+        XCTAssertEqual(json.dictionaryObject! as! [String: String], ["test": "case"])
         json.dictionaryObject = ["name": "NAME"]
-        XCTAssertEqual(json.dictionaryObject! as! [String : String], ["name": "NAME"])
+        XCTAssertEqual(json.dictionaryObject! as! [String: String], ["name": "NAME"])
     }
 }

--- a/Tests/SwiftyJSONTests/MutabilityTests.swift
+++ b/Tests/SwiftyJSONTests/MutabilityTests.swift
@@ -130,7 +130,7 @@ class MutabilityTests: XCTestCase {
     }
 
     func testDictionaryRemovability() {
-        let dictionary: [String : Any] = ["key1": "Value1", "key2": 2, "key3": true]
+        let dictionary: [String: Any] = ["key1": "Value1", "key2": 2, "key3": true]
         var json = JSON(dictionary)
 
         json.dictionaryObject?.removeValue(forKey: "key1")

--- a/Tests/SwiftyJSONTests/NestedJSONTests.swift
+++ b/Tests/SwiftyJSONTests/NestedJSONTests.swift
@@ -83,6 +83,6 @@ class NestedJSONTests: XCTestCase {
             "outer_field": foo,
             "inner_json": inner
             ])
-        XCTAssertEqual(json2["inner_json"].rawValue as! [String : String], ["some_field": "12"])
+        XCTAssertEqual(json2["inner_json"].rawValue as! [String: String], ["some_field": "12"])
     }
 }

--- a/Tests/SwiftyJSONTests/PrintableTests.swift
+++ b/Tests/SwiftyJSONTests/PrintableTests.swift
@@ -98,7 +98,7 @@ class PrintableTests: XCTestCase {
     }
 
     func testDictionaryWithStrings() {
-        let dict = ["foo": "{\"bar\":123}"] as [String : Any]
+        let dict = ["foo": "{\"bar\":123}"] as [String: Any]
         let json = JSON(dict)
         var debugDescription = json.debugDescription.replacingOccurrences(of: "\n", with: "")
         debugDescription = debugDescription.replacingOccurrences(of: " ", with: "")

--- a/Tests/SwiftyJSONTests/SequenceTypeTests.swift
+++ b/Tests/SwiftyJSONTests/SequenceTypeTests.swift
@@ -127,11 +127,11 @@ class SequenceTypeTests: XCTestCase {
             index += 1
         }
         XCTAssertEqual(index, 3)
-        XCTAssertEqual((array[0] as! [String : Int])["1"]!, 1)
-        XCTAssertEqual((array[0] as! [String : Int])["2"]!, 2)
-        XCTAssertEqual((array[1] as! [String : String])["a"]!, "A")
-        XCTAssertEqual((array[1] as! [String : String])["b"]!, "B")
-        XCTAssertEqual((array[2] as! [String : NSNull])["null"]!, NSNull())
+        XCTAssertEqual((array[0] as! [String: Int])["1"]!, 1)
+        XCTAssertEqual((array[0] as! [String: Int])["2"]!, 2)
+        XCTAssertEqual((array[1] as! [String: String])["a"]!, "A")
+        XCTAssertEqual((array[1] as! [String: String])["b"]!, "B")
+        XCTAssertEqual((array[2] as! [String: NSNull])["null"]!, NSNull())
     }
 
     func testDictionaryAllNumber() {


### PR DESCRIPTION
remove spacing between `key` and `:` for swift dictionary defining convention