### PR TITLE
Double string fix

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -921,6 +921,12 @@ extension JSON {
     public var number: NSNumber? {
         get {
             switch self.type {
+            case .string:
+                let decimal: NSDecimalNumber? = NSDecimalNumber(string: self.object as? String)
+                if decimal == NSDecimalNumber.notANumber {  // indicates parse error
+                    return nil
+                }
+                return decimal
             case .number:
                 return self.rawNumber
             case .bool:

--- a/Tests/SwiftyJSONTests/NumberTests.swift
+++ b/Tests/SwiftyJSONTests/NumberTests.swift
@@ -97,6 +97,12 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(json.boolValue, false)
         XCTAssertEqual(json.doubleValue, 0.0)
         XCTAssertEqual(json.numberValue, 0)
+        
+        json = "9876543210.123456789"
+        XCTAssertEqual(json.double!, 9876543210.123456789)
+        XCTAssertEqual(json.doubleValue, 9876543210.123456789)
+        XCTAssertEqual(json.numberValue, 9876543210.123456789)
+        XCTAssertEqual(json.stringValue, "9876543210.123456789")
     }
 
     func testFloat() {

--- a/Tests/SwiftyJSONTests/NumberTests.swift
+++ b/Tests/SwiftyJSONTests/NumberTests.swift
@@ -33,10 +33,17 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(json.stringValue, "9876543210.123457")
 
         json.string = "1000000000000000000000000000.1"
-        XCTAssertNil(json.number)
+        XCTAssertEqual(json.number!.description, "1000000000000000000000000000.1" )
+        XCTAssertEqual(json.number!, 1000000000000000000000000000.1 )
         XCTAssertEqual(json.numberValue.description, "1000000000000000000000000000.1")
-
+        XCTAssertEqual(json.numberValue, 1000000000000000000000000000.1)
+        
+        json.string = "swift"
+        XCTAssertNil(json.number)
+        XCTAssertEqual(json.numberValue, 0)
+        
         json.string = "1e+27"
+        XCTAssertEqual(json.number!.description, "1000000000000000000000000000")
         XCTAssertEqual(json.numberValue.description, "1000000000000000000000000000")
 
         //setter


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

What behavior was changed?
Added code for .double to handle strings. Now returns optional or nil.
What code was refactored / updated to support this change?
// MARK: - Number
extension JSON {

//Optional number
public var number: NSNumber? 
What issues are related to this PR? Or why was this change introduced?
When trying to convert a string into a .double, it always returned nil
Checklist - While not every PR needs it, new features should consider this list:

 Does this have tests?
Yes
Does this have documentation?
No, just adds optional parity to .doubleValue
 Does this break the public API (Requires major version bump)?
Don't believe so
 Is this a new feature (Requires minor version bump)?
No, this is a bug fix.