### PR TITLE
Add ability to store a date 

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -1459,18 +1459,29 @@ public enum writingOptionsKeys {
 // MARK: - Date
 
 extension JSON {
-    public var date: Date {
+    public var date: Date? {
         get {
-            return Date(timeIntervalSince1970: self.doubleValue)
+            let df = DateFormatter()
+            df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+            return df.date(from: self.stringValue)
         }
         set {
-            let double: Double = newValue.timeIntervalSince1970
-            self.doubleValue = double
+            if let nv = newValue {
+                let df = DateFormatter()
+                df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+                self.stringValue = df.string(from: nv)
+            } else {
+                self.string = nil
+            }
         }
     }
-    public func dateString(format: String = "yyyy-MM-dd HH:mm:Ss") -> String {
+    public func dateString(format: String = "yyyy-MM-dd HH:mm:ss") -> String? {
+        guard let date = self.date else {
+            return nil
+        }
+        
         let df = DateFormatter()
         df.dateFormat = format
-        return df.string(from: self.date)
+        return df.string(from: date)
     }
 }

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -1468,4 +1468,9 @@ extension JSON {
             self.doubleValue = double
         }
     }
+    public func dateString(format: String = "yyyy-MM-dd HH:mm:Ss") -> String {
+        let df = DateFormatter()
+        df.dateFormat = format
+        return df.string(from: self.date)
+    }
 }

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -1455,3 +1455,17 @@ public enum writingOptionsKeys {
 	case maxObjextDepth
 	case encoding
 }
+
+// MARK: - Date
+
+extension JSON {
+    public var date: Date {
+        get {
+            return Date(timeIntervalSince1970: self.doubleValue)
+        }
+        set {
+            let double: Double = newValue.timeIntervalSince1970
+            self.doubleValue = double
+        }
+    }
+}

--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		5DD502911D9B21810004C112 /* NestedJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD502901D9B21810004C112 /* NestedJSONTests.swift */; };
 		5DD502921D9B21810004C112 /* NestedJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD502901D9B21810004C112 /* NestedJSONTests.swift */; };
 		5DD502931D9B21810004C112 /* NestedJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD502901D9B21810004C112 /* NestedJSONTests.swift */; };
+		63FC91E41FB456640099BB09 /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FC91E31FB456640099BB09 /* DateTests.swift */; };
+		63FC91E51FB456640099BB09 /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FC91E31FB456640099BB09 /* DateTests.swift */; };
+		63FC91E61FB456640099BB09 /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FC91E31FB456640099BB09 /* DateTests.swift */; };
 		7236B4EE1BAC14150020529B /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8491E1D19CD6DAE00CCFAE6 /* SwiftyJSON.swift */; };
 		7236B4F11BAC14150020529B /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C459EF41A910334008C9A41 /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -117,6 +120,7 @@
 		2E4FEFE019575BE100351305 /* SwiftyJSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftyJSON.h; sourceTree = "<group>"; };
 		2E4FEFE619575BE100351305 /* SwiftyJSON iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftyJSON iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DD502901D9B21810004C112 /* NestedJSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedJSONTests.swift; sourceTree = "<group>"; };
+		63FC91E31FB456640099BB09 /* DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTests.swift; sourceTree = "<group>"; };
 		7236B4F61BAC14150020529B /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7236B4F71BAC14150020529B /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		9C459EF61A9103B1008C9A41 /* Info-macOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-macOS.plist"; sourceTree = "<group>"; };
@@ -264,6 +268,7 @@
 				A863BE2719EED46F0092A41F /* RawTests.swift */,
 				A8B66C8B19E51D6500540692 /* DictionaryTests.swift */,
 				A830A6941E5B2DD8001D7F6D /* MutabilityTests.swift */,
+				63FC91E31FB456640099BB09 /* DateTests.swift */,
 				A8B66C8D19E52F4200540692 /* ArrayTests.swift */,
 				2E4FEFEB19575BE100351305 /* Supporting Files */,
 			);
@@ -595,6 +600,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63FC91E41FB456640099BB09 /* DateTests.swift in Sources */,
 				1B587CC61DDE04770012D8DB /* MergeTests.swift in Sources */,
 				A87080E819E439DA00CDE086 /* NumberTests.swift in Sources */,
 				A87080E419E3C2A600CDE086 /* SequenceTypeTests.swift in Sources */,
@@ -634,6 +640,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63FC91E51FB456640099BB09 /* DateTests.swift in Sources */,
 				1B587CC71DDE04780012D8DB /* MergeTests.swift in Sources */,
 				9C459EFB1A9103C1008C9A41 /* SequenceTypeTests.swift in Sources */,
 				9C459F001A9103C1008C9A41 /* ComparableTests.swift in Sources */,
@@ -657,6 +664,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63FC91E61FB456640099BB09 /* DateTests.swift in Sources */,
 				1B587CC81DDE04790012D8DB /* MergeTests.swift in Sources */,
 				A8580F801BCF69A000DA927B /* PerformanceTests.swift in Sources */,
 				A8580F811BCF69A000DA927B /* BaseTests.swift in Sources */,

--- a/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON macOS.xcscheme
+++ b/SwiftyJSON.xcodeproj/xcshareddata/xcschemes/SwiftyJSON macOS.xcscheme
@@ -41,7 +41,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Tests/SwiftyJSONTests/DateTests.swift
+++ b/Tests/SwiftyJSONTests/DateTests.swift
@@ -16,4 +16,26 @@ class DateTests: XCTestCase {
         json.date = date
         XCTAssertEqual(json.date.timeIntervalSince1970, date.timeIntervalSince1970)
     }
+    
+    func testDateFormat() {
+        
+        let date = Date()
+        var json = JSON()
+        json.date = date
+        
+        let components = Calendar(identifier: Calendar.Identifier.gregorian).dateComponents(in: .current, from: date)
+        let year = json.dateString(format: "yyyy")
+        let month = json.dateString(format: "MM")
+        let day = json.dateString(format: "dd")
+        let hour = json.dateString(format: "HH")
+        let minute = json.dateString(format: "mm")
+        let second = json.dateString(format: "ss")
+        
+        XCTAssertEqual(Int(year), components.year)
+        XCTAssertEqual(Int(month), components.month)
+        XCTAssertEqual(Int(day), components.day)
+        XCTAssertEqual(Int(hour), components.hour)
+        XCTAssertEqual(Int(minute), components.minute)
+        XCTAssertEqual(Int(second), components.second)
+    }
 }

--- a/Tests/SwiftyJSONTests/DateTests.swift
+++ b/Tests/SwiftyJSONTests/DateTests.swift
@@ -1,0 +1,19 @@
+//
+//  DateTests.swift
+//  SwiftyJSON
+//
+//  Created by David Evans on 09/11/2017.
+//
+
+import XCTest
+import SwiftyJSON
+
+class DateTests: XCTestCase {
+    
+    func testDates() {
+        let date = Date()
+        var json = JSON()
+        json.date = date
+        XCTAssertEqual(json.date.timeIntervalSince1970, date.timeIntervalSince1970)
+    }
+}

--- a/Tests/SwiftyJSONTests/DateTests.swift
+++ b/Tests/SwiftyJSONTests/DateTests.swift
@@ -6,17 +6,10 @@
 //
 
 import XCTest
-import SwiftyJSON
+@testable import SwiftyJSON
 
 class DateTests: XCTestCase {
-    
-    func testDates() {
-        let date = Date()
-        var json = JSON()
-        json.date = date
-        XCTAssertEqual(json.date.timeIntervalSince1970, date.timeIntervalSince1970)
-    }
-    
+
     func testDateFormat() {
         
         let date = Date()
@@ -24,12 +17,12 @@ class DateTests: XCTestCase {
         json.date = date
         
         let components = Calendar(identifier: Calendar.Identifier.gregorian).dateComponents(in: .current, from: date)
-        let year = json.dateString(format: "yyyy")
-        let month = json.dateString(format: "MM")
-        let day = json.dateString(format: "dd")
-        let hour = json.dateString(format: "HH")
-        let minute = json.dateString(format: "mm")
-        let second = json.dateString(format: "ss")
+        let year = json.dateString(format: "yyyy") ?? ""
+        let month = json.dateString(format: "MM") ?? ""
+        let day = json.dateString(format: "dd") ?? ""
+        let hour = json.dateString(format: "HH") ?? ""
+        let minute = json.dateString(format: "mm") ?? ""
+        let second = json.dateString(format: "ss") ?? ""
         
         XCTAssertEqual(Int(year), components.year)
         XCTAssertEqual(Int(month), components.month)
@@ -37,5 +30,12 @@ class DateTests: XCTestCase {
         XCTAssertEqual(Int(hour), components.hour)
         XCTAssertEqual(Int(minute), components.minute)
         XCTAssertEqual(Int(second), components.second)
+        
+        json.date = nil
+        XCTAssertNil(json.date)
+        
+        json.stringValue = "foo bar"
+        XCTAssertNil(json.date)
+        XCTAssertNil(json.dateString())
     }
 }


### PR DESCRIPTION
Added a convenience computed variable to allow users to store dates in a JSON object. This also comes with a function to get the date as a string in a specified format.

**Does this have tests?**
Yes - DateTests.swift

**Does this break the public API**
No - all other tests are passing

**Is this a new feature**
Yes - a minor version bump will be required