### PR TITLE
Support Codable protocol

### DIFF
--- a/Example/Playground.playground/Contents.swift
+++ b/Example/Playground.playground/Contents.swift
@@ -413,4 +413,3 @@ let stringRepresentionJson: JSON = JSON(stringRepresentationDict)
 let representation = stringRepresentionJson.rawString([.castNilToNSNull: true])
 print(representation!)
 // representation is "{\"1\":2,\"2\":\"two\",\"3\":null}", which represents {"1":2,"2":"two","3":null}
-

--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		5DD502911D9B21810004C112 /* NestedJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD502901D9B21810004C112 /* NestedJSONTests.swift */; };
 		5DD502921D9B21810004C112 /* NestedJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD502901D9B21810004C112 /* NestedJSONTests.swift */; };
 		5DD502931D9B21810004C112 /* NestedJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD502901D9B21810004C112 /* NestedJSONTests.swift */; };
+		712921EF2004E4EB00DA6340 /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712921EE2004E4EB00DA6340 /* CodableTests.swift */; };
+		712921F02004E4EB00DA6340 /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712921EE2004E4EB00DA6340 /* CodableTests.swift */; };
+		712921F12004E4EB00DA6340 /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712921EE2004E4EB00DA6340 /* CodableTests.swift */; };
 		7236B4EE1BAC14150020529B /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8491E1D19CD6DAE00CCFAE6 /* SwiftyJSON.swift */; };
 		7236B4F11BAC14150020529B /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C459EF41A910334008C9A41 /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -117,6 +120,7 @@
 		2E4FEFE019575BE100351305 /* SwiftyJSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftyJSON.h; sourceTree = "<group>"; };
 		2E4FEFE619575BE100351305 /* SwiftyJSON iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftyJSON iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DD502901D9B21810004C112 /* NestedJSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedJSONTests.swift; sourceTree = "<group>"; };
+		712921EE2004E4EB00DA6340 /* CodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableTests.swift; sourceTree = "<group>"; };
 		7236B4F61BAC14150020529B /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7236B4F71BAC14150020529B /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		9C459EF61A9103B1008C9A41 /* Info-macOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-macOS.plist"; sourceTree = "<group>"; };
@@ -265,6 +269,7 @@
 				A8B66C8B19E51D6500540692 /* DictionaryTests.swift */,
 				A830A6941E5B2DD8001D7F6D /* MutabilityTests.swift */,
 				A8B66C8D19E52F4200540692 /* ArrayTests.swift */,
+				712921EE2004E4EB00DA6340 /* CodableTests.swift */,
 				2E4FEFEB19575BE100351305 /* Supporting Files */,
 			);
 			name = SwiftyJSONTests;
@@ -604,6 +609,7 @@
 				A819C49F19E2EE5B00ADCC3D /* SubscriptTests.swift in Sources */,
 				A830A6951E5B2DD8001D7F6D /* MutabilityTests.swift in Sources */,
 				A863BE2819EED46F0092A41F /* RawTests.swift in Sources */,
+				712921EF2004E4EB00DA6340 /* CodableTests.swift in Sources */,
 				A885D1D219CF1EE6002FD4C3 /* BaseTests.swift in Sources */,
 				A8B66C8E19E52F4200540692 /* ArrayTests.swift in Sources */,
 				A8B66C8C19E51D6500540692 /* DictionaryTests.swift in Sources */,
@@ -643,6 +649,7 @@
 				9C459EFA1A9103C1008C9A41 /* BaseTests.swift in Sources */,
 				A830A6961E5B2DD8001D7F6D /* MutabilityTests.swift in Sources */,
 				9C459F041A9103C1008C9A41 /* DictionaryTests.swift in Sources */,
+				712921F02004E4EB00DA6340 /* CodableTests.swift in Sources */,
 				9C459EF91A9103C1008C9A41 /* PerformanceTests.swift in Sources */,
 				9C459EFE1A9103C1008C9A41 /* LiteralConvertibleTests.swift in Sources */,
 				9C459EFC1A9103C1008C9A41 /* PrintableTests.swift in Sources */,
@@ -666,6 +673,7 @@
 				A8580F841BCF69A000DA927B /* SubscriptTests.swift in Sources */,
 				A830A6971E5B2DD8001D7F6D /* MutabilityTests.swift in Sources */,
 				A8580F851BCF69A000DA927B /* LiteralConvertibleTests.swift in Sources */,
+				712921F12004E4EB00DA6340 /* CodableTests.swift in Sources */,
 				A8580F861BCF69A000DA927B /* RawRepresentableTests.swift in Sources */,
 				A8580F871BCF69A000DA927B /* ComparableTests.swift in Sources */,
 				A8580F881BCF69A000DA927B /* StringTests.swift in Sources */,

--- a/Tests/SwiftyJSONTests/CodableTests.swift
+++ b/Tests/SwiftyJSONTests/CodableTests.swift
@@ -1,0 +1,100 @@
+//  CodableTests.swift
+//
+//  Created by Lei Wang on 2018/1/9.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import XCTest
+import SwiftyJSON
+
+class CodableTests: XCTestCase {
+    
+    func testEncodeNull() {
+        var json = JSON([NSNull()])
+        _ = try! JSONEncoder().encode(json)
+        json = JSON([nil])
+        _ = try! JSONEncoder().encode(json)
+        let dictionary: [String: Any?] = ["key": nil]
+        json = JSON(dictionary)
+        _ = try! JSONEncoder().encode(json)
+    }
+    func testArrayCodable() {
+        let jsonString = """
+        [1,"false", ["A", 4.3231],"3",true]
+        """
+        var data = jsonString.data(using: .utf8)!
+        let json = try! JSONDecoder().decode(JSON.self, from: data)
+        XCTAssertEqual(json.arrayValue.first?.int, 1)
+        XCTAssertEqual(json[1].bool, nil)
+        XCTAssertEqual(json[1].string, "false")
+        XCTAssertEqual(json[3].string, "3")
+        XCTAssertEqual(json[2][1].double!, 4.3231)
+        XCTAssertEqual(json.arrayValue[0].bool, nil)
+        XCTAssertEqual(json.array!.last!.bool, true)
+        let jsonList = try! JSONDecoder().decode([JSON].self, from: data)
+        XCTAssertEqual(jsonList.first?.int, 1)
+        XCTAssertEqual(jsonList.last!.bool, true)
+        data = try! JSONEncoder().encode(json)
+        let list = try! JSONSerialization.jsonObject(with: data, options: []) as! [Any]
+        XCTAssertEqual(list[0] as! Int, 1)
+        XCTAssertEqual((list[2] as! [Any])[1] as! Float, 4.3231)
+    }
+    func testDictionaryCodable() {
+        let dictionary: [String: Any] = ["number": 9823.212, "name": "NAME", "list": [1234, 4.21223256], "object": ["sub_number": 877.2323, "sub_name": "sub_name"], "bool": true]
+        var data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let json = try! JSONDecoder().decode(JSON.self, from: data)
+        XCTAssertNotNil(json.dictionary)
+        XCTAssertEqual(json["number"].float, 9823.212)
+        XCTAssertEqual(json["list"].arrayObject is [Float], true)
+        XCTAssertEqual(json["object"]["sub_number"].float, 877.2323)
+        XCTAssertEqual(json["bool"].bool, true)
+        let jsonDict = try! JSONDecoder().decode([String: JSON].self, from: data)
+        XCTAssertEqual(jsonDict["number"]?.int, 9823)
+        XCTAssertEqual(jsonDict["object"]?["sub_name"], "sub_name")
+        data = try! JSONEncoder().encode(json)
+        var encoderDict = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
+        XCTAssertEqual(encoderDict["list"] as! [Float], [1234, 4.21223256])
+        XCTAssertEqual(encoderDict["bool"] as! Bool, true)
+        data = try! JSONEncoder().encode(jsonDict)
+        encoderDict = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
+        XCTAssertEqual(encoderDict["name"] as! String, dictionary["name"] as! String)
+        XCTAssertEqual((encoderDict["object"] as! [String: Any])["sub_number"] as! Float, 877.2323)
+    }
+    func testCodableModel() {
+        struct CodableModel: Codable {
+            let name: String
+            let number: Double
+            let bool: Bool
+            let list: [Double]
+            private let object: JSON
+            var subName: String? {
+                return object["sub_name"].string
+            }
+        }
+        let dictionary: [String: Any] = [
+            "number": 9823.212,
+            "name": "NAME",
+            "list": [1234, 4.21223256],
+            "object": ["sub_number": 877.2323, "sub_name": "sub_name"],
+            "bool": true]
+        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let model = try! JSONDecoder().decode(CodableModel.self, from: data)
+        XCTAssertEqual(model.subName, "sub_name")
+    }
+}


### PR DESCRIPTION
In some Codable instances, when we analyze a deep nested JSON field, it is very difficult to use. So if `JSON` implements Codable protocol, it can provide a very good solution, for example.

```swift
struct SomeDeepNestedModel: Codable {
    let id: Int64
    //some variables
    //...
    private var json: JSON?
    var theDeepNestedValue: String? {
        return json?["nested1"][1]["nested2"]["value"].string
    }
}
```

**Does this have tests?**
Yes - CodableTests.swift

**Does this break the public API?**
No

**Is this a new feature (Requires minor version bump)?**
Yes

**Does this have documentation?**
No
  