### PR TITLE
Allow to create JSON object from any Encodable object, and to decode into a Decodable object conveniently

### DIFF
--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -131,6 +131,22 @@ public struct JSON {
         }
     }
 
+    /**
+     Parses the object confirming to Encodable protocol into a JSON object using JSONEncoder
+     
+     - parameter encodable: the object confirming to Encodable protocol
+     
+     - returns: the created JSON object
+     */
+    public init<T: Encodable>(parseEncodable encodable: T) {
+        do {
+            let data = try JSONEncoder().encode(encodable)
+            try self.init(data: data)
+        } catch {
+            self.init(NSNull())
+        }
+    }
+
 	/**
 	 Parses the JSON string into a JSON object
 	
@@ -952,6 +968,17 @@ extension JSON {
         set {
             self.object = newValue
         }
+    }
+}
+
+// MARK: - Decodable Object
+
+extension JSON {
+
+    //Optional object
+    public func decode<T: Decodable>(_ decodableType: T.Type) -> T? {
+        guard let data = try? self.rawData() else { return nil }
+        return try? JSONDecoder().decode(decodableType, from: data)
     }
 }
 


### PR DESCRIPTION
This pull request provides a convenient way for SwitfyJSON to integrate with other Codable objects.

example:
```swift
struct Student: Codable {
    let id: Int, name: String
}

let student = Student(id: 1, name: "Bill")
let json = JSON(parseEncodable: student)
print(json.rawString(.utf8, options: [])!) // {"id":1,"name":"Bill"}
print(json.decode(Student.self)!.name) // Bill
```