### PR TITLE
Dynamic Member Lookup introduced in Swift 4.2, now we can use dot, instead of brackets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ osx_image: xcode10.0
 xcode_sdk: iphonesimulator12.0
 script:
 - set -o pipefail
-- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,OS=12,name=iPhone 6" build-for-testing test | xcpretty
+- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,OS=12.0,name=iPhone 6" build-for-testing test | xcpretty
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON macOS" build-for-testing test | xcpretty
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON tvOS" -destination "platform=tvOS Simulator,name=Apple TV" build-for-testing test | xcpretty
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ osx_image: xcode10.0
 xcode_sdk: iphonesimulator12.0
 script:
 - set -o pipefail
-- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,name=iPhone 6" build-for-testing test | xcpretty
+- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,OS=12,name=iPhone 6" build-for-testing test | xcpretty
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON macOS" build-for-testing test | xcpretty
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON tvOS" -destination "platform=tvOS Simulator,name=Apple TV" build-for-testing test | xcpretty
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ script:
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,name=iPhone 6" build-for-testing test | xcpretty
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON macOS" build-for-testing test | xcpretty
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON tvOS" -destination "platform=tvOS Simulator,name=Apple TV" build-for-testing test | xcpretty
+env:
+- SWIFT_VERSION=4.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ osx_image: xcode10.0
 xcode_sdk: iphonesimulator12.0
 script:
 - set -o pipefail
-- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,OS=12.0,name=iPhone 6" build-for-testing test | xcpretty
+- travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON iOS" -destination "platform=iOS Simulator,name=iPhone 6" build-for-testing test | xcpretty
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON macOS" build-for-testing test | xcpretty
 - travis_retry xcodebuild -workspace SwiftyJSON.xcworkspace -scheme "SwiftyJSON tvOS" -destination "platform=tvOS Simulator,name=Apple TV" build-for-testing test | xcpretty
-env:
-- SWIFT_VERSION=4.2.0

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -94,7 +94,7 @@ public enum Type: Int {
 }
 
 // MARK: - JSON Base
-
+@dynamicMemberLookup
 public struct JSON {
 
 	/**
@@ -538,6 +538,31 @@ extension JSON {
             self[path] = newValue
         }
     }
+    
+    /**
+     Find a json in the complex data structures by using dynamic member name.
+     
+     - parameter path: The target json's path. Example:
+     
+     you seperate your path by . (dot)
+     
+     let name = json.name
+     The same as: let name = json["name"]
+     
+     let phoneNumber = json.user.contactInfo.phoneNumber
+     The same as: let name = json["user"]["contactInfo"]["phoneNumber"]
+     
+     - returns: Return a json found by the path or a null json with error
+     */
+    public subscript(dynamicMember member: String) -> JSON {
+        get {
+            return self[sub:member]
+        }
+        set {
+            self[sub:member] = newValue
+        }
+    }
+
 }
 
 // MARK: - LiteralConvertible

--- a/Source/SwiftyJSON.swift
+++ b/Source/SwiftyJSON.swift
@@ -562,7 +562,6 @@ extension JSON {
             self[sub:member] = newValue
         }
     }
-
 }
 
 // MARK: - LiteralConvertible

--- a/SwiftyJSON.podspec
+++ b/SwiftyJSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "SwiftyJSON"
-  s.version     = "4.1.0"
+  s.version     = "4.2.0"
   s.summary     = "SwiftyJSON makes it easy to deal with JSON data in Swift"
   s.homepage    = "https://github.com/SwiftyJSON/SwiftyJSON"
   s.license     = { :type => "MIT" }

--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		712921F12004E4EB00DA6340 /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712921EE2004E4EB00DA6340 /* CodableTests.swift */; };
 		7236B4EE1BAC14150020529B /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8491E1D19CD6DAE00CCFAE6 /* SwiftyJSON.swift */; };
 		7236B4F11BAC14150020529B /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8ED1DB49215FB47C002423BF /* DynamicMemberLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ED1DB48215FB47C002423BF /* DynamicMemberLookupTests.swift */; };
 		9C459EF41A910334008C9A41 /* SwiftyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E4FEFE019575BE100351305 /* SwiftyJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C459EF51A910361008C9A41 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8491E1D19CD6DAE00CCFAE6 /* SwiftyJSON.swift */; };
 		9C459EF81A9103C1008C9A41 /* Tests.json in Resources */ = {isa = PBXBuildFile; fileRef = A885D1DA19CFCFF0002FD4C3 /* Tests.json */; };
@@ -123,6 +124,7 @@
 		712921EE2004E4EB00DA6340 /* CodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableTests.swift; sourceTree = "<group>"; };
 		7236B4F61BAC14150020529B /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7236B4F71BAC14150020529B /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		8ED1DB48215FB47C002423BF /* DynamicMemberLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicMemberLookupTests.swift; sourceTree = "<group>"; };
 		9C459EF61A9103B1008C9A41 /* Info-macOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-macOS.plist"; sourceTree = "<group>"; };
 		9C7DFC5B1A9102BD005AA3F7 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C7DFC651A9102BD005AA3F7 /* SwiftyJSON macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftyJSON macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -263,6 +265,7 @@
 				A819C49619E1A7DD00ADCC3D /* LiteralConvertibleTests.swift */,
 				A819C49819E1B10300ADCC3D /* RawRepresentableTests.swift */,
 				A87080E519E3DF7800CDE086 /* ComparableTests.swift */,
+				8ED1DB48215FB47C002423BF /* DynamicMemberLookupTests.swift */,
 				A87080E919E43C0700CDE086 /* StringTests.swift */,
 				A87080E719E439DA00CDE086 /* NumberTests.swift */,
 				A863BE2719EED46F0092A41F /* RawTests.swift */,
@@ -622,6 +625,7 @@
 				A819C49719E1A7DD00ADCC3D /* LiteralConvertibleTests.swift in Sources */,
 				A87080EA19E43C0700CDE086 /* StringTests.swift in Sources */,
 				A87080E619E3DF7800CDE086 /* ComparableTests.swift in Sources */,
+				8ED1DB49215FB47C002423BF /* DynamicMemberLookupTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -853,7 +853,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -877,7 +877,7 @@
 				PRODUCT_NAME = SwiftyJSON;
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Tests/SwiftyJSONTests/DynamicMemberLookupTests.swift
+++ b/Tests/SwiftyJSONTests/DynamicMemberLookupTests.swift
@@ -1,0 +1,73 @@
+//
+//  DynamicMemberLookupTests.swift
+//  SwiftyJSON iOS Tests
+//
+//  Created by ios 4 on 9/29/18.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import XCTest
+import SwiftyJSON
+class DynamicMemberLookupTests: XCTestCase {
+    func testDictionaryDynamicLookupString() {
+        var json: JSON = JSON(rawValue: ["a": "aoo", "bb": "bpp", "z": "zoo"] as NSDictionary)!
+        XCTAssertTrue(json.a == "aoo")
+        XCTAssertEqual(json.bb, JSON("bpp"))
+        XCTAssertTrue(json.z == "zoo")
+        json.bb = "update"
+        XCTAssertTrue(json.a == "aoo")
+        XCTAssertTrue(json.bb == "update")
+        XCTAssertTrue(json.z == "zoo")
+    }
+    func testMultilevelDynamicLookUpGetter() {
+        var json: JSON = ["user": ["id": 987654, "info":
+            ["name": "farshad", "email": "farshadjahanmanesh@gmail.com"],
+                                   "feeds": [98833, 23443, 213239, 23232]]]
+        XCTAssertEqual(json["user", "id"], 987654)
+        XCTAssertEqual(json["user", "info", "name"], "farshad")
+        XCTAssertEqual(json["user", "info", "email"], "farshadjahanmanesh@gmail.com")
+        XCTAssertEqual(json["user", "feeds"], [98833, 23443, 213239, 23232])
+    }
+    func testMultilevelDynamicLookUpSetter() {
+        var json: JSON = ["user": ["id": 987654, "info":
+            ["name": "farshad","email": "farshadjahanmanesh@gmail.com"],
+                                   "feeds": [98833, 23443, 213239, 23232]]]
+        json.user.info.name = "jim"
+        XCTAssertEqual(json.user.id, 987654)
+        XCTAssertEqual(json.user.info.name, "jim")
+        XCTAssertEqual(json.user.info.email, "farshadjahanmanesh@gmail.com")
+        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
+        json.user.info.email = "jim@hotmail.com"
+        XCTAssertEqual(json.user.id, 987654)
+        XCTAssertEqual(json.user.info.name, "jim")
+        XCTAssertEqual(json.user.info.email, "jim@hotmail.com")
+        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
+        json.user.info = ["name": "tom", "email": "tom@qq.com"]
+        XCTAssertEqual(json.user.id, 987654)
+        XCTAssertEqual(json.user.info.name, "tom")
+        XCTAssertEqual(json.user.info.email, "tom@qq.com")
+        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
+        json.user.feeds = [77323, 2313, 4545, 323]
+        XCTAssertEqual(json.user.id, 987654)
+        XCTAssertEqual(json.user.info.name, "tom")
+        XCTAssertEqual(json.user.info.email, "tom@qq.com")
+        XCTAssertEqual(json.user.feeds, [77323, 2313, 4545, 323])
+    }
+
+}

--- a/Tests/SwiftyJSONTests/DynamicMemberLookupTests.swift
+++ b/Tests/SwiftyJSONTests/DynamicMemberLookupTests.swift
@@ -37,21 +37,21 @@ class DynamicMemberLookupTests: XCTestCase {
     }
     func testMultilevelDynamicLookUpGetter() {
         var json: JSON = ["user": ["id": 987654, "info":
-            ["name": "farshad", "email": "farshadjahanmanesh@gmail.com"],
+            ["name": "farshad", "email": "sam@gmail.com"],
                                    "feeds": [98833, 23443, 213239, 23232]]]
         XCTAssertEqual(json["user", "id"], 987654)
         XCTAssertEqual(json["user", "info", "name"], "farshad")
-        XCTAssertEqual(json["user", "info", "email"], "farshadjahanmanesh@gmail.com")
+        XCTAssertEqual(json["user", "info", "email"], "sam@gmail.com")
         XCTAssertEqual(json["user", "feeds"], [98833, 23443, 213239, 23232])
     }
     func testMultilevelDynamicLookUpSetter() {
         var json: JSON = ["user": ["id": 987654, "info":
-            ["name": "farshad","email": "farshadjahanmanesh@gmail.com"],
+            ["name": "farshad","email": "sam@gmail.com"],
                                    "feeds": [98833, 23443, 213239, 23232]]]
         json.user.info.name = "jim"
         XCTAssertEqual(json.user.id, 987654)
         XCTAssertEqual(json.user.info.name, "jim")
-        XCTAssertEqual(json.user.info.email, "farshadjahanmanesh@gmail.com")
+        XCTAssertEqual(json.user.info.email, "sam@gmail.com")
         XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
         json.user.info.email = "jim@hotmail.com"
         XCTAssertEqual(json.user.id, 987654)

--- a/Tests/SwiftyJSONTests/DynamicMemberLookupTests.swift
+++ b/Tests/SwiftyJSONTests/DynamicMemberLookupTests.swift
@@ -37,8 +37,8 @@ class DynamicMemberLookupTests: XCTestCase {
     }
 
     func testMultilevelDynamicLookUpSetterAndGetter() {
-        var json: JSON = ["user": ["id": 987654, "info":
-            ["name": "farshad","email": "sam@gmail.com"],
+        var json: JSON = ["user": ["id": 987654,
+                                   "info":["name": "farshad","email": "sam@gmail.com"],
                                    "feeds": [98833, 23443, 213239, 23232]]]
         json.user.info.name = "jim"
         XCTAssertEqual(json.user.id, 987654)

--- a/Tests/SwiftyJSONTests/DynamicMemberLookupTests.swift
+++ b/Tests/SwiftyJSONTests/DynamicMemberLookupTests.swift
@@ -35,16 +35,8 @@ class DynamicMemberLookupTests: XCTestCase {
         XCTAssertTrue(json.bb == "update")
         XCTAssertTrue(json.z == "zoo")
     }
-    func testMultilevelDynamicLookUpGetter() {
-        var json: JSON = ["user": ["id": 987654, "info":
-            ["name": "farshad", "email": "sam@gmail.com"],
-                                   "feeds": [98833, 23443, 213239, 23232]]]
-        XCTAssertEqual(json["user", "id"], 987654)
-        XCTAssertEqual(json["user", "info", "name"], "farshad")
-        XCTAssertEqual(json["user", "info", "email"], "sam@gmail.com")
-        XCTAssertEqual(json["user", "feeds"], [98833, 23443, 213239, 23232])
-    }
-    func testMultilevelDynamicLookUpSetter() {
+
+    func testMultilevelDynamicLookUpSetterAndGetter() {
         var json: JSON = ["user": ["id": 987654, "info":
             ["name": "farshad","email": "sam@gmail.com"],
                                    "feeds": [98833, 23443, 213239, 23232]]]

--- a/Tests/SwiftyJSONTests/SubscriptTests.swift
+++ b/Tests/SwiftyJSONTests/SubscriptTests.swift
@@ -219,21 +219,22 @@ class SubscriptTests: XCTestCase {
         XCTAssertTrue(json.a == "aoo")
         XCTAssertEqual(json.bb, JSON("bpp"))
         XCTAssertTrue(json.z == "zoo")
-        
         json.bb = "update"
         XCTAssertTrue(json.a == "aoo")
         XCTAssertTrue(json.bb == "update")
         XCTAssertTrue(json.z == "zoo")
     }
     func testMultilevelDynamicLookUpGetter() {
-        var json: JSON = ["user": ["id": 987654, "info": ["name": "farshad", "email": "farshadjahanmanesh@gmail.com"], "feeds": [98833, 23443, 213239, 23232]]]
+        var json: JSON = ["user": ["id": 987654, "info": ["name": "farshad",
+                                "email": "farshadjahanmanesh@gmail.com"], "feeds": [98833, 23443, 213239, 23232]]]
         XCTAssertEqual(json["user", "id"], 987654)
         XCTAssertEqual(json["user", "info", "name"], "farshad")
         XCTAssertEqual(json["user", "info", "email"], "farshadjahanmanesh@gmail.com")
         XCTAssertEqual(json["user", "feeds"], [98833, 23443, 213239, 23232])
     }
     func testMultilevelDynamicLookUpSetter() {
-        var json: JSON = ["user": ["id": 987654, "info": ["name": "farshad", "email": "farshadjahanmanesh@gmail.com"], "feeds": [98833, 23443, 213239, 23232]]]
+        var json: JSON = ["user": ["id": 987654, "info": ["name": "farshad",
+                                "email": "farshadjahanmanesh@gmail.com"], "feeds": [98833, 23443, 213239, 23232]]]
         json.user.info.name = "jim"
         XCTAssertEqual(json.user.id, 987654)
         XCTAssertEqual(json.user.info.name, "jim")

--- a/Tests/SwiftyJSONTests/SubscriptTests.swift
+++ b/Tests/SwiftyJSONTests/SubscriptTests.swift
@@ -214,6 +214,47 @@ class SubscriptTests: XCTestCase {
         XCTAssertEqual(json["Type"]["Value"].error, SwiftyJSONError.notExist)
         XCTAssertEqual(json["Type", "Value"].error, SwiftyJSONError.notExist)
     }
+    func testDictionaryDynamicLookupString() {
+        var json: JSON = JSON(rawValue: ["a": "aoo", "bb": "bpp", "z": "zoo"] as NSDictionary)!
+        XCTAssertTrue(json.a == "aoo")
+        XCTAssertEqual(json.bb, JSON("bpp"))
+        XCTAssertTrue(json.z == "zoo")
+        
+        json.bb = "update"
+        XCTAssertTrue(json.a == "aoo")
+        XCTAssertTrue(json.bb == "update")
+        XCTAssertTrue(json.z == "zoo")
+    }
+    func testMultilevelDynamicLookUpGetter() {
+        var json: JSON = ["user": ["id": 987654, "info": ["name": "farshad", "email": "farshadjahanmanesh@gmail.com"], "feeds": [98833, 23443, 213239, 23232]]]
+        XCTAssertEqual(json["user", "id"], 987654)
+        XCTAssertEqual(json["user", "info", "name"], "farshad")
+        XCTAssertEqual(json["user", "info", "email"], "farshadjahanmanesh@gmail.com")
+        XCTAssertEqual(json["user", "feeds"], [98833, 23443, 213239, 23232])
+    }
+    func testMultilevelDynamicLookUpSetter() {
+        var json: JSON = ["user": ["id": 987654, "info": ["name": "farshad", "email": "farshadjahanmanesh@gmail.com"], "feeds": [98833, 23443, 213239, 23232]]]
+        json.user.info.name = "jim"
+        XCTAssertEqual(json.user.id, 987654)
+        XCTAssertEqual(json.user.info.name, "jim")
+        XCTAssertEqual(json.user.info.email, "farshadjahanmanesh@gmail.com")
+        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
+        json.user.info.email = "jim@hotmail.com"
+        XCTAssertEqual(json.user.id, 987654)
+        XCTAssertEqual(json.user.info.name, "jim")
+        XCTAssertEqual(json.user.info.email, "jim@hotmail.com")
+        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
+        json.user.info = ["name": "tom", "email": "tom@qq.com"]
+        XCTAssertEqual(json.user.id, 987654)
+        XCTAssertEqual(json.user.info.name, "tom")
+        XCTAssertEqual(json.user.info.email, "tom@qq.com")
+        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
+        json.user.feeds = [77323, 2313, 4545, 323]
+        XCTAssertEqual(json.user.id, 987654)
+        XCTAssertEqual(json.user.info.name, "tom")
+        XCTAssertEqual(json.user.info.email, "tom@qq.com")
+        XCTAssertEqual(json.user.feeds, [77323, 2313, 4545, 323])
+    }
 
     func testMultilevelGetter() {
         let json: JSON = [[[[["one": 1]]]]]

--- a/Tests/SwiftyJSONTests/SubscriptTests.swift
+++ b/Tests/SwiftyJSONTests/SubscriptTests.swift
@@ -214,49 +214,7 @@ class SubscriptTests: XCTestCase {
         XCTAssertEqual(json["Type"]["Value"].error, SwiftyJSONError.notExist)
         XCTAssertEqual(json["Type", "Value"].error, SwiftyJSONError.notExist)
     }
-    func testDictionaryDynamicLookupString() {
-        var json: JSON = JSON(rawValue: ["a": "aoo", "bb": "bpp", "z": "zoo"] as NSDictionary)!
-        XCTAssertTrue(json.a == "aoo")
-        XCTAssertEqual(json.bb, JSON("bpp"))
-        XCTAssertTrue(json.z == "zoo")
-        json.bb = "update"
-        XCTAssertTrue(json.a == "aoo")
-        XCTAssertTrue(json.bb == "update")
-        XCTAssertTrue(json.z == "zoo")
-    }
-    func testMultilevelDynamicLookUpGetter() {
-        var json: JSON = ["user": ["id": 987654, "info": ["name": "farshad",
-                                "email": "farshadjahanmanesh@gmail.com"], "feeds": [98833, 23443, 213239, 23232]]]
-        XCTAssertEqual(json["user", "id"], 987654)
-        XCTAssertEqual(json["user", "info", "name"], "farshad")
-        XCTAssertEqual(json["user", "info", "email"], "farshadjahanmanesh@gmail.com")
-        XCTAssertEqual(json["user", "feeds"], [98833, 23443, 213239, 23232])
-    }
-    func testMultilevelDynamicLookUpSetter() {
-        var json: JSON = ["user": ["id": 987654, "info": ["name": "farshad",
-                                "email": "farshadjahanmanesh@gmail.com"], "feeds": [98833, 23443, 213239, 23232]]]
-        json.user.info.name = "jim"
-        XCTAssertEqual(json.user.id, 987654)
-        XCTAssertEqual(json.user.info.name, "jim")
-        XCTAssertEqual(json.user.info.email, "farshadjahanmanesh@gmail.com")
-        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
-        json.user.info.email = "jim@hotmail.com"
-        XCTAssertEqual(json.user.id, 987654)
-        XCTAssertEqual(json.user.info.name, "jim")
-        XCTAssertEqual(json.user.info.email, "jim@hotmail.com")
-        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
-        json.user.info = ["name": "tom", "email": "tom@qq.com"]
-        XCTAssertEqual(json.user.id, 987654)
-        XCTAssertEqual(json.user.info.name, "tom")
-        XCTAssertEqual(json.user.info.email, "tom@qq.com")
-        XCTAssertEqual(json.user.feeds, [98833, 23443, 213239, 23232])
-        json.user.feeds = [77323, 2313, 4545, 323]
-        XCTAssertEqual(json.user.id, 987654)
-        XCTAssertEqual(json.user.info.name, "tom")
-        XCTAssertEqual(json.user.info.email, "tom@qq.com")
-        XCTAssertEqual(json.user.feeds, [77323, 2313, 4545, 323])
-    }
-
+    
     func testMultilevelGetter() {
         let json: JSON = [[[[["one": 1]]]]]
         XCTAssertEqual(json[[0, 0, 0, 0, "one"]].int!, 1)


### PR DESCRIPTION
This proposal introduces a new @dynamicMemberLookup attribute. Types that use it provide "dot" syntax for arbitrary names which are resolved at runtime - in a completely type safe way. This provides syntactic sugar that allows the user to write

[introduce-user-defined-dynamic-member-lookup-types](https://github.com/apple/swift-evolution/blob/master/proposals/0195-dynamic-member-lookup.md#introduce-user-defined-dynamic-member-lookup-types)

i've added a subscript function with dynamic member, so users can use dot instead of [],
   
     let name = json.name
     //The same as: let name = json["name"]
     
     let phoneNumber = json.user.contactInfo.phoneNumber
     //The same as: let name = json["user"]["contactInfo"]["phoneNumber"]



 - [yes ] Does this have tests?
 - [ yes] Does this have documentation?
 - [ no] Does this break the public API (Requires major version bump)?
 - [ no] Is this a new feature (Requires minor version bump)?