### PR TITLE
Add Swift 4 package manifest

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:4.0
+
+import PackageDescription
+
+let package = Package(
+        name: "SwiftyJSON",
+        products: [
+            .library(name: "SwiftyJSON", targets: ["SwiftyJSON"])
+        ],
+        targets: [
+            .target(name: "SwiftyJSON",
+                    path: "Source"),
+            .testTarget(name: "SwiftyJSONTests",
+                    dependencies: ["SwiftyJSON"],
+                    path: "Tests"),
+        ]
+)

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -12,6 +12,6 @@ let package = Package(
                     path: "Source"),
             .testTarget(name: "SwiftyJSONTests",
                     dependencies: ["SwiftyJSON"],
-                    path: "Tests"),
+                    path: "Tests")
         ]
 )


### PR DESCRIPTION
Since Swift 4.2 old `PackageDescription` v3 is deprecated for removal. As a result, for all dependent packages we see this warning:
```
warning: PackageDescription API v3 is deprecated and will be removed in the future; used by package(s): SwiftyJSON
```

This PR adds a modern version of `Package.swift` manifest, which will only be used for Swift ≥4.0.
No source code is changed/restructured.