### PR TITLE
add stringNonEmpty property to string extension

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -799,6 +799,19 @@ extension JSON {
             object = newValue
         }
     }
+
+    // Non-empty string
+    public var stringNonEmpty: String? {
+        get {
+            switch string {
+            case .some(let value) where !value.isEmpty: return string
+            default:                                    return nil
+            }
+        }
+        set {
+            string = newValue
+        }
+    }
 }
 
 // MARK: - Number

--- a/Tests/SwiftJSONTests/StringTests.swift
+++ b/Tests/SwiftJSONTests/StringTests.swift
@@ -30,10 +30,17 @@ class StringTests: XCTestCase {
         var json = JSON("abcdefg hijklmn;opqrst.?+_()")
         XCTAssertEqual(json.string!, "abcdefg hijklmn;opqrst.?+_()")
         XCTAssertEqual(json.stringValue, "abcdefg hijklmn;opqrst.?+_()")
+        XCTAssertEqual(json.stringNonEmpty!, "abcdefg hijklmn;opqrst.?+_()")
 
         json.string = "12345?67890.@#"
         XCTAssertEqual(json.string!, "12345?67890.@#")
         XCTAssertEqual(json.stringValue, "12345?67890.@#")
+        XCTAssertEqual(json.stringNonEmpty!, "12345?67890.@#")
+
+        json.string = ""
+        XCTAssertEqual(json.string!, "")
+        XCTAssertEqual(json.stringValue, "")
+        XCTAssertEqual(json.stringNonEmpty, nil)
     }
 
     func testUrl() {


### PR DESCRIPTION
What was changed and why:

- Sometimes string from json is emtpy, aka `""`, and app want to handle empty same as nil.  The `stringNonEmpty` property will return nil when got an empty string from json.

Checklist

 - [x] Does this have tests?