### PR TITLE
Fixes #1041 and #1038 on linux variants

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -1203,7 +1203,7 @@ public func >= (lhs: JSON, rhs: JSON) -> Bool {
 public func > (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber > rhs.rawNumber
+    case (.number, .number): return lhs.rawNumber as NSNumber > rhs.rawNumber as NSNumber
     case (.string, .string): return lhs.rawString > rhs.rawString
     default:                 return false
     }
@@ -1212,7 +1212,7 @@ public func > (lhs: JSON, rhs: JSON) -> Bool {
 public func < (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber < rhs.rawNumber
+    case (.number, .number): return lhs.rawNumber as NSNumber > rhs.rawNumber as NSNumber
     case (.string, .string): return lhs.rawString < rhs.rawString
     default:                 return false
     }


### PR DESCRIPTION
Compilation fails due to tighter type restrictions on newer swift builds. Casting works and produces no errors.

 - [ ] Does this have tests?
Unnecessary, existing tests cover this case (it is purely a type definition in two places)
 - [ ] Does this have documentation?
Not needed
 - [ ] Does this break the public API (Requires major version bump)?
No
 - [ ] Is this a new feature (Requires minor version bump)?
No