### PR TITLE
Raised a 'invalidJSON' error if initialization JSON data is corrupt.

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -109,6 +109,7 @@ public struct JSON {
                 try self.init(data: object)
             } catch {
                 self.init(jsonObject: NSNull())
+                self.error = SwiftyJSONError.invalidJSON
             }
         default:
             self.init(jsonObject: object)
@@ -127,6 +128,7 @@ public struct JSON {
 			self.init(data)
 		} else {
 			self.init(NSNull())
+			self.error = SwiftyJSONError.invalidJSON
 		}
 	}
 

--- a/Tests/SwiftJSONTests/BaseTests.swift
+++ b/Tests/SwiftJSONTests/BaseTests.swift
@@ -26,6 +26,7 @@ import SwiftyJSON
 class BaseTests: XCTestCase {
 
     var testData: Data!
+    var corruptJSONString: String!
 
     override func setUp() {
 
@@ -38,6 +39,8 @@ class BaseTests: XCTestCase {
         } else {
             XCTFail("Can't find the test JSON file")
         }
+        
+        self.corruptJSONString = "{\n This is a corrupt JSON example."
     }
 
     override func tearDown() {
@@ -273,5 +276,10 @@ class BaseTests: XCTestCase {
         } catch {
             // everything is OK
         }
+    }
+    
+    func testCorruptJSON() {
+        XCTAssertEqual(JSON(parseJSON: self.corruptJSONString).error, SwiftyJSONError.invalidJSON)
+        XCTAssertEqual(JSON(Data(self.corruptJSONString.utf8)).error, SwiftyJSONError.invalidJSON)
     }
 }


### PR DESCRIPTION
I think you should tell the upper layer of the corrupted JSON data error. And the meaning of ‘null' and corruption is different in JSON, we better distinguish.

- What behavior was changed?
   Set the error parameter to '.invalidJSON' when JSON parsing was failed.

- What is the application scenario？
   I need to check the correctness of the JSON file returned from the remote, or I need to check the 
   correctness of the JSON file passed in by the upper layer.