### PR TITLE
Performance refactoring

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -324,6 +324,24 @@ public enum Index<T: Any>: Comparable {
         default:                                              return false
         }
     }
+    
+    static public func <= (lhs: Index, rhs: Index) -> Bool {
+        switch (lhs, rhs) {
+        case (.array(let left), .array(let right)):           return left <= right
+        case (.dictionary(let left), .dictionary(let right)): return left <= right
+        case (.null, .null):                                  return true
+        default:                                              return false
+        }
+    }
+    
+    static public func >= (lhs: Index, rhs: Index) -> Bool {
+        switch (lhs, rhs) {
+        case (.array(let left), .array(let right)):           return left >= right
+        case (.dictionary(let left), .dictionary(let right)): return left >= right
+        case (.null, .null):                                  return true
+        default:                                              return false
+        }
+    }
 }
 
 public typealias JSONIndex = Index<JSON>

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -222,13 +222,13 @@ public struct JSON {
     /// JSON type, fileprivate setter
     public var type: Type {
         switch content {
-        case .array: return .array
-        case .bool: return .bool
-        case .dictionary: return .dictionary
-        case .null: return .null
-        case .number: return .number
-        case .string: return .string
-        case .unknown: return .unknown
+        case .array:        return .array
+        case .bool:         return .bool
+        case .dictionary:   return .dictionary
+        case .null:         return .null
+        case .number:       return .number
+        case .string:       return .string
+        case .unknown:      return .unknown
         }
     }
     fileprivate var content: Content
@@ -240,12 +240,12 @@ public struct JSON {
     public var object: Any {
         get {
             switch content {
-            case .array(let rawArray): return rawArray
-            case .dictionary(let rawDictionary): return rawDictionary
-            case .string(let rawString): return rawString
-            case .number(let rawNumber): return rawNumber
-            case .bool(let rawBool): return rawBool
-            case .null, .unknown: return NSNull()
+            case .array(let rawArray):              return rawArray
+            case .dictionary(let rawDictionary):    return rawDictionary
+            case .string(let rawString):            return rawString
+            case .number(let rawNumber):            return rawNumber
+            case .bool(let rawBool):                return rawBool
+            case .null, .unknown:                   return NSNull()
             }
         }
         set {
@@ -339,17 +339,17 @@ extension JSON: Swift.Collection {
 
     public var startIndex: Index {
         switch content {
-        case .array(let rawArray): return .array(rawArray.startIndex)
-        case .dictionary(let rawDictionary): return .dictionary(rawDictionary.startIndex)
-        default:          return .null
+        case .array(let rawArray):              return .array(rawArray.startIndex)
+        case .dictionary(let rawDictionary):    return .dictionary(rawDictionary.startIndex)
+        default:                                return .null
         }
     }
 
     public var endIndex: Index {
         switch content {
-        case .array(let rawArray):      return .array(rawArray.endIndex)
-        case .dictionary(let rawDictionary): return .dictionary(rawDictionary.endIndex)
-        default:          return .null
+        case .array(let rawArray):              return .array(rawArray.endIndex)
+        case .dictionary(let rawDictionary):    return .dictionary(rawDictionary.endIndex)
+        default:                                return .null
         }
     }
 
@@ -497,7 +497,7 @@ extension JSON {
         set {
             switch path.count {
             case 0: return
-            case 1: self[sub:path[0]].object = newValue.object
+            case 1: self[sub: path[0]].object = newValue.object
             default:
                 var aPath = path
                 aPath.remove(at: 0)
@@ -599,7 +599,6 @@ extension JSON: Swift.RawRepresentable {
         guard JSONSerialization.isValidJSONObject(object) else {
             throw SwiftyJSONError.invalidJSON
         }
-
         return try JSONSerialization.data(withJSONObject: object, options: opt)
 	}
 
@@ -691,11 +690,11 @@ extension JSON: Swift.RawRepresentable {
             } catch _ {
                 return nil
             }
-        case .string(let rawString): return rawString
-        case .number(let rawNumber): return rawNumber.stringValue
-        case .bool(let rawBool): return rawBool.description
-        case .null: return "null"
-        case .unknown: return nil
+        case .string(let rawString):    return rawString
+        case .number(let rawNumber):    return rawNumber.stringValue
+        case .bool(let rawBool):        return rawBool.description
+        case .null:                     return "null"
+        case .unknown:                  return nil
         }
     }
 }
@@ -738,9 +737,9 @@ extension JSON {
         }
         set {
             if let newValue = newValue {
-                self.update(content: .array(newValue), error: nil)
+                update(content: .array(newValue), error: nil)
             } else {
-                self.update(content: .null, error: nil)
+                update(content: .null, error: nil)
             }
         }
     }
@@ -786,8 +785,8 @@ extension JSON { // : Swift.Bool
     public var bool: Bool? {
         get {
             switch content {
-            case .bool(let rawBool): return rawBool
-            default:    return nil
+            case .bool(let rawBool):    return rawBool
+            default:                    return nil
             }
         }
         set {
@@ -803,10 +802,10 @@ extension JSON { // : Swift.Bool
     public var boolValue: Bool {
         get {
             switch content {
-            case .bool(let rawBool): return rawBool
-            case .number(let rawNumber): return rawNumber.boolValue
-            case .string(let rawString): return ["true", "y", "t", "yes", "1"].contains { rawString.caseInsensitiveCompare($0) == .orderedSame }
-            default: return false
+            case .bool(let rawBool):        return rawBool
+            case .number(let rawNumber):    return rawNumber.boolValue
+            case .string(let rawString):    return ["true", "y", "t", "yes", "1"].contains { rawString.caseInsensitiveCompare($0) == .orderedSame }
+            default:                        return false
             }
         }
         set {
@@ -823,13 +822,13 @@ extension JSON {
     public var string: String? {
         get {
             switch content {
-            case .string(let rawString): return rawString
-            default: return nil
+            case .string(let rawString):    return rawString
+            default:                        return nil
             }
         }
         set {
-            if let rawString = newValue {
-                update(content: .string(rawString), error: nil)
+            if let newValue = newValue {
+                update(content: .string(newValue), error: nil)
             } else {
                 update(content: .null, error: nil)
             }
@@ -866,8 +865,8 @@ extension JSON {
             }
         }
         set {
-            if let rawNumber = newValue {
-                update(content: .number(rawNumber), error: nil)
+            if let newValue = newValue {
+                update(content: .number(newValue), error: nil)
             } else {
                 update(content: .null, error: nil)
             }
@@ -1174,57 +1173,57 @@ extension Content: Comparable {
     static func == (lhs: Content, rhs: Content) -> Bool {
 
         switch (lhs, rhs) {
-        case let (.number(l), .number(r)): return l == r
-        case let (.string(l), .string(r)): return l == r
-        case let (.bool(l), .bool(r)): return l == r
-        case let (.array(l), .array(r)): return l as NSArray == r as NSArray
-        case let (.dictionary(l), .dictionary(r)): return l as NSDictionary == r as NSDictionary
-        case (.null, .null):     return true
-        default:                 return false
+        case let (.number(l), .number(r)):          return l == r
+        case let (.string(l), .string(r)):          return l == r
+        case let (.bool(l), .bool(r)):              return l == r
+        case let (.array(l), .array(r)):            return l as NSArray == r as NSArray
+        case let (.dictionary(l), .dictionary(r)):  return l as NSDictionary == r as NSDictionary
+        case (.null, .null):                        return true
+        default:                                    return false
         }
     }
 
     static func <= (lhs: Content, rhs: Content) -> Bool {
         
         switch (lhs, rhs) {
-        case let (.number(l), .number(r)): return l <= r
-        case let (.string(l), .string(r)): return l <= r
-        case let (.bool(l), .bool(r)): return l == r
-        case let (.array(l), .array(r)): return l as NSArray == r as NSArray
-        case let (.dictionary(l), .dictionary(r)): return l as NSDictionary == r as NSDictionary
-        case (.null, .null):     return true
-        default:                 return false
+        case let (.number(l), .number(r)):          return l <= r
+        case let (.string(l), .string(r)):          return l <= r
+        case let (.bool(l), .bool(r)):              return l == r
+        case let (.array(l), .array(r)):            return l as NSArray == r as NSArray
+        case let (.dictionary(l), .dictionary(r)):  return l as NSDictionary == r as NSDictionary
+        case (.null, .null):                        return true
+        default:                                    return false
         }
     }
 
     static func >= (lhs: Content, rhs: Content) -> Bool {
 
         switch (lhs, rhs) {
-        case let (.number(l), .number(r)): return l >= r
-        case let (.string(l), .string(r)): return l >= r
-        case let (.bool(l), .bool(r)): return l == r
-        case let (.array(l), .array(r)): return l as NSArray == r as NSArray
-        case let (.dictionary(l), .dictionary(r)): return l as NSDictionary == r as NSDictionary
-        case (.null, .null):     return true
-        default:                 return false
+        case let (.number(l), .number(r)):          return l >= r
+        case let (.string(l), .string(r)):          return l >= r
+        case let (.bool(l), .bool(r)):              return l == r
+        case let (.array(l), .array(r)):            return l as NSArray == r as NSArray
+        case let (.dictionary(l), .dictionary(r)):  return l as NSDictionary == r as NSDictionary
+        case (.null, .null):                        return true
+        default:                                    return false
         }
     }
 
     static func > (lhs: Content, rhs: Content) -> Bool {
 
         switch (lhs, rhs) {
-        case let (.number(l), .number(r)): return l > r
-        case let (.string(l), .string(r)): return l > r
-        default:                 return false
+        case let (.number(l), .number(r)):  return l > r
+        case let (.string(l), .string(r)):  return l > r
+        default:                            return false
         }
     }
 
     static func < (lhs: Content, rhs: Content) -> Bool {
 
         switch (lhs, rhs) {
-        case let (.number(l), .number(r)): return l < r
-        case let (.string(l), .string(r)): return l < r
-        default:                 return false
+        case let (.number(l), .number(r)):  return l < r
+        case let (.string(l), .string(r)):  return l < r
+        default:                            return false
         }
     }
 }

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -1229,60 +1229,23 @@ extension Content: Comparable {
 extension JSON: Swift.Comparable {}
 
 public func == (lhs: JSON, rhs: JSON) -> Bool {
-
-    switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber == rhs.rawNumber
-    case (.string, .string): return lhs.rawString == rhs.rawString
-    case (.bool, .bool):     return lhs.rawBool == rhs.rawBool
-    case (.array, .array):   return lhs.rawArray as NSArray == rhs.rawArray as NSArray
-    case (.dictionary, .dictionary): return lhs.rawDictionary as NSDictionary == rhs.rawDictionary as NSDictionary
-    case (.null, .null):     return true
-    default:                 return false
-    }
+    return lhs.content == rhs.content
 }
 
 public func <= (lhs: JSON, rhs: JSON) -> Bool {
-
-    switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber <= rhs.rawNumber
-    case (.string, .string): return lhs.rawString <= rhs.rawString
-    case (.bool, .bool):     return lhs.rawBool == rhs.rawBool
-    case (.array, .array):   return lhs.rawArray as NSArray == rhs.rawArray as NSArray
-    case (.dictionary, .dictionary): return lhs.rawDictionary as NSDictionary == rhs.rawDictionary as NSDictionary
-    case (.null, .null):     return true
-    default:                 return false
-    }
+    return lhs.content <= rhs.content
 }
 
 public func >= (lhs: JSON, rhs: JSON) -> Bool {
-
-    switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber >= rhs.rawNumber
-    case (.string, .string): return lhs.rawString >= rhs.rawString
-    case (.bool, .bool):     return lhs.rawBool == rhs.rawBool
-    case (.array, .array):   return lhs.rawArray as NSArray == rhs.rawArray as NSArray
-    case (.dictionary, .dictionary): return lhs.rawDictionary as NSDictionary == rhs.rawDictionary as NSDictionary
-    case (.null, .null):     return true
-    default:                 return false
-    }
+    return lhs.content >= rhs.content
 }
 
 public func > (lhs: JSON, rhs: JSON) -> Bool {
-
-    switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber > rhs.rawNumber
-    case (.string, .string): return lhs.rawString > rhs.rawString
-    default:                 return false
-    }
+    return lhs.content > rhs.content
 }
 
 public func < (lhs: JSON, rhs: JSON) -> Bool {
-
-    switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber < rhs.rawNumber
-    case (.string, .string): return lhs.rawString < rhs.rawString
-    default:                 return false
-    }
+    return lhs.content < rhs.content
 }
 
 private let trueNumber = NSNumber(value: true)

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -139,7 +139,7 @@ public struct JSON {
 		if let data = jsonString.data(using: .utf8) {
 			self.init(data)
 		} else {
-			self.init(NSNull())
+            self.init(jsonObject: NSNull())
 		}
 	}
     

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -158,26 +158,8 @@ public struct JSON {
 	 - returns: The created JSON
 	 */
     fileprivate init(jsonObject: Any) {
-        
-        // TODO: - move logic to function [ content(for object: Any) -> Content? ]
-        
-        switch unwrap(jsonObject) {
-        case let number as NSNumber:
-            content = number.isBool ? .bool(number.boolValue) : .number(number)
-        case let string as String:
-            content = .string(string)
-        case _ as NSNull:
-            content = .null
-        case nil:
-            content = .null
-        case let array as [Any]:
-            content = .array(array)
-        case let dictionary as [String: Any]:
-            content = .dictionary(dictionary)
-        default:
-            content = .unknown
-            error = SwiftyJSONError.unsupportedType
-        }
+        self.content = resolveContent(for: jsonObject)
+        self.error = (self.content == .unknown) ? .unsupportedType : nil
     }
 
 	/**
@@ -300,6 +282,25 @@ public struct JSON {
 }
 
 /// Private method to unwarp an object recursively
+private func resolveContent(for jsonObject: Any) -> Content {
+    switch unwrap(jsonObject) {
+    case let number as NSNumber:
+        return number.isBool ? .bool(number.boolValue) : .number(number)
+    case let string as String:
+        return .string(string)
+    case _ as NSNull:
+        return .null
+    case nil:
+        return .null
+    case let array as [Any]:
+        return .array(array)
+    case let dictionary as [String: Any]:
+        return .dictionary(dictionary)
+    default:
+        return .unknown
+    }
+}
+
 private func unwrap(_ object: Any) -> Any {
     switch object {
     case let json as JSON:

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -253,7 +253,7 @@ public struct JSON {
         }
     }
     
-    private mutating func updateContent(to newContent: Content, error: SwiftyJSONError?) {
+    private mutating func update(content newContent: Content, error: SwiftyJSONError?) {
         self.content = newContent
         self.error = error
     }
@@ -738,9 +738,9 @@ extension JSON {
         }
         set {
             if let newValue = newValue {
-                self.updateContent(to: .array(newValue), error: nil)
+                self.update(content: .array(newValue), error: nil)
             } else {
-                self.updateContent(to: .null, error: nil)
+                self.update(content: .null, error: nil)
             }
         }
     }
@@ -770,9 +770,9 @@ extension JSON {
         }
         set {
             if let newValue = newValue {
-                updateContent(to: .dictionary(newValue), error: nil)
+                update(content: .dictionary(newValue), error: nil)
             } else {
-                updateContent(to: .null, error: nil)
+                update(content: .null, error: nil)
             }
         }
     }
@@ -792,9 +792,9 @@ extension JSON { // : Swift.Bool
         }
         set {
             if let newValue = newValue {
-                updateContent(to: .bool(newValue), error: nil)
+                update(content: .bool(newValue), error: nil)
             } else {
-                updateContent(to: .null, error: nil)
+                update(content: .null, error: nil)
             }
         }
     }
@@ -810,7 +810,7 @@ extension JSON { // : Swift.Bool
             }
         }
         set {
-            updateContent(to: .bool(newValue), error: nil)
+            update(content: .bool(newValue), error: nil)
         }
     }
 }
@@ -829,9 +829,9 @@ extension JSON {
         }
         set {
             if let rawString = newValue {
-                updateContent(to: .string(rawString), error: nil)
+                update(content: .string(rawString), error: nil)
             } else {
-                updateContent(to: .null, error: nil)
+                update(content: .null, error: nil)
             }
         }
     }
@@ -847,7 +847,7 @@ extension JSON {
             }
         }
         set {
-            updateContent(to: .string(newValue), error: nil)
+            update(content: .string(newValue), error: nil)
         }
     }
 }
@@ -867,9 +867,9 @@ extension JSON {
         }
         set {
             if let rawNumber = newValue {
-                updateContent(to: .number(rawNumber), error: nil)
+                update(content: .number(rawNumber), error: nil)
             } else {
-                updateContent(to: .null, error: nil)
+                update(content: .null, error: nil)
             }
         }
     }
@@ -887,7 +887,7 @@ extension JSON {
             }
         }
         set {
-            updateContent(to: .number(newValue), error: nil)
+            update(content: .number(newValue), error: nil)
         }
     }
 }
@@ -898,7 +898,7 @@ extension JSON {
 
     public var null: NSNull? {
         set {
-            updateContent(to: .null, error: nil)
+            update(content: .null, error: nil)
         }
         get {
             switch content {
@@ -939,9 +939,9 @@ extension JSON {
         }
         set {
             if let newValue = newValue {
-                updateContent(to: .string(newValue.absoluteString), error: nil)
+                update(content: .string(newValue.absoluteString), error: nil)
             } else {
-                updateContent(to: .null, error: nil)
+                update(content: .null, error: nil)
             }
         }
     }

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -219,7 +219,7 @@ public struct JSON {
         }
     }
 
-    /// JSON type, fileprivate setter
+    /// JSON type
     public var type: Type {
         switch content {
         case .array:        return .array
@@ -231,6 +231,8 @@ public struct JSON {
         case .unknown:      return .unknown
         }
     }
+    
+    /// Content of JSON
     fileprivate var content: Content
 
     /// Error in JSON, fileprivate setter
@@ -240,8 +242,8 @@ public struct JSON {
     public var object: Any {
         get {
             switch content {
-            case .array(let rawArray):              return rawArray
             case .dictionary(let rawDictionary):    return rawDictionary
+            case .array(let rawArray):              return rawArray
             case .string(let rawString):            return rawString
             case .number(let rawNumber):            return rawNumber
             case .bool(let rawBool):                return rawBool
@@ -262,31 +264,31 @@ public struct JSON {
     /// The static null JSON
     @available(*, unavailable, renamed:"null")
     public static var nullJSON: JSON { return null }
-    public static var null: JSON { return JSON(NSNull()) }
+    public static let null = JSON(NSNull())
 }
 
-/// Private methods to resolve content AND error of raw jsonObject
+/// Private method for resolving raw json object's content and error
 private func resolveContentAndError(for jsonObject: Any) -> (Content, SwiftyJSONError?) {
     let content = resolveContent(for: jsonObject)
     let error: SwiftyJSONError? = (content == .unknown) ? .unsupportedType : nil
     return (content, error)
 }
 
-/// Private methods to resolve content of raw jsonObject
+/// Private method for resolving raw json object's content
 private func resolveContent(for jsonObject: Any) -> Content {
     switch unwrap(jsonObject) {
-    case let number as NSNumber:
-        return number.isBool ? .bool(number.boolValue) : .number(number)
-    case let string as String:
-        return .string(string)
-    case _ as NSNull:
-        return .null
-    case nil:
-        return .null
-    case let array as [Any]:
-        return .array(array)
     case let dictionary as [String: Any]:
         return .dictionary(dictionary)
+    case let array as [Any]:
+        return .array(array)
+    case nil:
+        return .null
+    case is NSNull:
+        return .null
+    case let string as String:
+        return .string(string)
+    case let number as NSNumber:
+        return number.isBool ? .bool(number.boolValue) : .number(number)
     default:
         return .unknown
     }

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -328,34 +328,44 @@ extension JSON: Swift.Collection {
     public typealias Index = JSONRawIndex
 
     public var startIndex: Index {
-        switch type {
-        case .array:      return .array(rawArray.startIndex)
-        case .dictionary: return .dictionary(rawDictionary.startIndex)
+        switch content {
+        case .array(let rawArray): return .array(rawArray.startIndex)
+        case .dictionary(let rawDictionary): return .dictionary(rawDictionary.startIndex)
         default:          return .null
         }
     }
 
     public var endIndex: Index {
-        switch type {
-        case .array:      return .array(rawArray.endIndex)
-        case .dictionary: return .dictionary(rawDictionary.endIndex)
+        switch content {
+        case .array(let rawArray):      return .array(rawArray.endIndex)
+        case .dictionary(let rawDictionary): return .dictionary(rawDictionary.endIndex)
         default:          return .null
         }
     }
 
     public func index(after i: Index) -> Index {
-        switch i {
-        case .array(let idx):      return .array(rawArray.index(after: idx))
-        case .dictionary(let idx): return .dictionary(rawDictionary.index(after: idx))
-        default:                   return .null
+        switch content {
+        case .array(let rawArray):
+            guard case .array(let idx) = i else { return .null }
+            return .array(rawArray.index(after: idx))
+        case .dictionary(let rawDictionary):
+            guard case .dictionary(let idx) = i else { return .null }
+            return .dictionary(rawDictionary.index(after: idx))
+        default:
+            return .null
         }
     }
 
     public subscript (position: Index) -> (String, JSON) {
-        switch position {
-        case .array(let idx):      return (String(idx), JSON(rawArray[idx]))
-        case .dictionary(let idx): return (rawDictionary[idx].key, JSON(rawDictionary[idx].value))
-        default:                   return ("", JSON.null)
+        switch content {
+        case .array(let rawArray):
+            guard case .array(let idx) = position else { return ("", JSON.null) }
+            return (String(idx), JSON(rawArray[idx]))
+        case .dictionary(let rawDictionary):
+            guard case .dictionary(let idx) = position else { return ("", JSON.null) }
+            return (rawDictionary[idx].key, JSON(rawDictionary[idx].value))
+        default:
+            return ("", JSON.null)
         }
     }
 }

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -1280,9 +1280,12 @@ private let falseObjCType = String(cString: falseNumber.objCType)
 
 extension NSNumber {
     fileprivate var isBool: Bool {
-        let objCType = String(cString: self.objCType)
-        if (self.compare(trueNumber) == .orderedSame && objCType == trueObjCType) || (self.compare(falseNumber) == .orderedSame && objCType == falseObjCType) {
-            return true
+        if self.compare(trueNumber) == .orderedSame {
+            let objCType = String(cString: self.objCType)
+            return objCType == trueObjCType
+        } else if self.compare(falseNumber) == .orderedSame {
+            let objCType = String(cString: self.objCType)
+            return objCType == trueObjCType
         } else {
             return false
         }

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -253,6 +253,7 @@ public struct JSON {
         }
     }
     
+    /// Mutating method that updates JSON's underlying content and error
     private mutating func update(content newContent: Content, error: SwiftyJSONError?) {
         self.content = newContent
         self.error = error
@@ -264,13 +265,14 @@ public struct JSON {
     public static var null: JSON { return JSON(NSNull()) }
 }
 
-/// Private method to unwarp an object recursively
+/// Private methods to resolve content AND error of raw jsonObject
 private func resolveContentAndError(for jsonObject: Any) -> (Content, SwiftyJSONError?) {
     let content = resolveContent(for: jsonObject)
     let error: SwiftyJSONError? = (content == .unknown) ? .unsupportedType : nil
     return (content, error)
 }
 
+/// Private methods to resolve content of raw jsonObject
 private func resolveContent(for jsonObject: Any) -> Content {
     switch unwrap(jsonObject) {
     case let number as NSNumber:
@@ -290,6 +292,7 @@ private func resolveContent(for jsonObject: Any) -> Content {
     }
 }
 
+/// Private method to unwarp an object recursively
 private func unwrap(_ object: Any) -> Any {
     switch object {
     case let json as JSON:

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -142,6 +142,13 @@ public struct JSON {
 			self.init(NSNull())
 		}
 	}
+    
+    // TODO: - add documentation
+    
+    fileprivate init(error: SwiftyJSONError) {
+        self.content = .null
+        self.error = error
+    }
 
 	/**
 	 Creates a JSON using the object.
@@ -151,7 +158,26 @@ public struct JSON {
 	 - returns: The created JSON
 	 */
     fileprivate init(jsonObject: Any) {
-        object = jsonObject
+        
+        // TODO: - move logic to function [ content(for object: Any) -> Content? ]
+        
+        switch unwrap(jsonObject) {
+        case let number as NSNumber:
+            content = number.isBool ? .bool(number.boolValue) : .number(number)
+        case let string as String:
+            content = .string(string)
+        case _ as NSNull:
+            content = .null
+        case nil:
+            content = .null
+        case let array as [Any]:
+            content = .array(array)
+        case let dictionary as [String: Any]:
+            content = .dictionary(dictionary)
+        default:
+            content = .unknown
+            error = SwiftyJSONError.unsupportedType
+        }
     }
 
 	/**
@@ -207,16 +233,19 @@ public struct JSON {
         }
     }
 
-    /// Private object
-    fileprivate var rawArray: [Any] = []
-    fileprivate var rawDictionary: [String: Any] = [:]
-    fileprivate var rawString: String = ""
-    fileprivate var rawNumber: NSNumber = 0
-    fileprivate var rawNull: NSNull = NSNull()
-    fileprivate var rawBool: Bool = false
-
     /// JSON type, fileprivate setter
-    public fileprivate(set) var type: Type = .null
+    public var type: Type {
+        switch content {
+        case .array: return .array
+        case .bool: return .bool
+        case .dictionary: return .dictionary
+        case .null: return .null
+        case .number: return .number
+        case .string: return .string
+        case .unknown: return .unknown
+        }
+    }
+    fileprivate var content: Content
 
     /// Error in JSON, fileprivate setter
     public fileprivate(set) var error: SwiftyJSONError?

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -297,11 +297,7 @@ private func unwrap(_ object: Any) -> Any {
     case let array as [Any]:
         return array.map(unwrap)
     case let dictionary as [String: Any]:
-        var d = dictionary
-        dictionary.forEach { pair in
-            d[pair.key] = unwrap(pair.value)
-        }
-        return d
+        return dictionary.mapValues(unwrap)
     default:
         return object
     }

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -67,14 +67,27 @@ JSON's type definitions.
 
 See http://www.json.org
 */
+
+/// Options of JSON content
+fileprivate enum Content {
+    case number(NSNumber)
+    case bool(Bool)
+    case string(String)
+    case null
+    case array([Any])
+    case dictionary([String: Any])
+    case unknown
+}
+
+/// Type of JSON content
 public enum Type: Int {
-	case number
-	case string
-	case bool
-	case array
-	case dictionary
-	case null
-	case unknown
+    case number
+    case string
+    case bool
+    case array
+    case dictionary
+    case null
+    case unknown
 }
 
 // MARK: - JSON Base

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -143,8 +143,13 @@ public struct JSON {
 		}
 	}
     
-    // TODO: - add documentation
+    /**
+     Creates a JSON using error parameter.
     
+     - parameter error: The error to be linked to JSON.
+    
+     - returns: The created JSON with error.
+     */
     fileprivate init(error: SwiftyJSONError) {
         self.content = .null
         self.error = error

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -1169,6 +1169,67 @@ extension JSON {
         }
     }
 }
+// MARK: - Content: Comparable
+
+extension Content: Comparable {
+    
+    static func == (lhs: Content, rhs: Content) -> Bool {
+
+        switch (lhs, rhs) {
+        case let (.number(l), .number(r)): return l == r
+        case let (.string(l), .string(r)): return l == r
+        case let (.bool(l), .bool(r)): return l == r
+        case let (.array(l), .array(r)): return l as NSArray == r as NSArray
+        case let (.dictionary(l), .dictionary(r)): return l as NSDictionary == r as NSDictionary
+        case (.null, .null):     return true
+        default:                 return false
+        }
+    }
+
+    static func <= (lhs: Content, rhs: Content) -> Bool {
+        
+        switch (lhs, rhs) {
+        case let (.number(l), .number(r)): return l <= r
+        case let (.string(l), .string(r)): return l <= r
+        case let (.bool(l), .bool(r)): return l == r
+        case let (.array(l), .array(r)): return l as NSArray == r as NSArray
+        case let (.dictionary(l), .dictionary(r)): return l as NSDictionary == r as NSDictionary
+        case (.null, .null):     return true
+        default:                 return false
+        }
+    }
+
+    static func >= (lhs: Content, rhs: Content) -> Bool {
+
+        switch (lhs, rhs) {
+        case let (.number(l), .number(r)): return l >= r
+        case let (.string(l), .string(r)): return l >= r
+        case let (.bool(l), .bool(r)): return l == r
+        case let (.array(l), .array(r)): return l as NSArray == r as NSArray
+        case let (.dictionary(l), .dictionary(r)): return l as NSDictionary == r as NSDictionary
+        case (.null, .null):     return true
+        default:                 return false
+        }
+    }
+
+    static func > (lhs: Content, rhs: Content) -> Bool {
+
+        switch (lhs, rhs) {
+        case let (.number(l), .number(r)): return l > r
+        case let (.string(l), .string(r)): return l > r
+        default:                 return false
+        }
+    }
+
+    static func < (lhs: Content, rhs: Content) -> Bool {
+
+        switch (lhs, rhs) {
+        case let (.number(l), .number(r)): return l < r
+        case let (.string(l), .string(r)): return l < r
+        default:                 return false
+        }
+    }
+}
 
 // MARK: - Comparable
 

--- a/Tests/SwiftJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftJSONTests/PerformanceTests.swift
@@ -60,7 +60,7 @@ class PerformanceTests: XCTestCase {
             return
         }
         self.measure {
-            for _ in 1...100 {
+            for _ in 1...100_000 {
                 let object: Any? = json.object
                 XCTAssertTrue(object != nil)
             }
@@ -73,7 +73,7 @@ class PerformanceTests: XCTestCase {
             return
         }
         self.measure {
-            for _ in 1...100 {
+            for _ in 1...1_000 {
                 autoreleasepool {
                     if let array = json.array {
                         XCTAssertTrue(array.count > 0)
@@ -89,7 +89,7 @@ class PerformanceTests: XCTestCase {
             return
         }
         self.measure {
-            for _ in 1...100 {
+            for _ in 1...1_000 {
                 autoreleasepool {
                     if let dictionary = json.dictionary {
                         XCTAssertTrue(dictionary.count > 0)
@@ -116,7 +116,7 @@ class PerformanceTests: XCTestCase {
 
     func testLargeDictionaryMethodPerformance() {
         var data: [String: JSON] = [:]
-        (0...100000).forEach { n in
+        (0...100_000).forEach { n in
             data["\(n)"] = JSON([
                 "name": "item\(n)",
                 "id": n
@@ -127,7 +127,7 @@ class PerformanceTests: XCTestCase {
         self.measure {
             autoreleasepool {
                 if let dictionary = json.dictionary {
-                    XCTAssertTrue(dictionary.count == 100001)
+                    XCTAssertTrue(dictionary.count == 100_001)
                 } else {
                     XCTFail("dictionary should not be nil")
                 }
@@ -150,7 +150,7 @@ class PerformanceTests: XCTestCase {
             ]
         
         self.measure {
-            (1...1_000).forEach { _ in
+            (1...10_000).forEach { _ in
                 let resultValue = dictionary["one"]["two"]["three"]["four"]["five"]
                 XCTAssertTrue(resultValue == "result")
             }

--- a/Tests/SwiftJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftJSONTests/PerformanceTests.swift
@@ -134,4 +134,26 @@ class PerformanceTests: XCTestCase {
             }
         }
     }
+    
+    func testLongPathDictionaryLookupPerformance() {
+        
+        let dictionary: JSON = [
+                "one": [
+                    "two": [
+                        "three": [
+                            "four": [
+                                "five": "result"
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        
+        self.measure {
+            (1...1_000).forEach { _ in
+                let resultValue = dictionary["one"]["two"]["three"]["four"]["five"]
+                XCTAssertTrue(resultValue == "result")
+            }
+        }
+    }
 }


### PR DESCRIPTION
 - What behaviour was changed?
In order to improve SwiftyJSON performance I changed how underlying object of JSON is being stored. Previously there were 6 non-optional properties: rawArray, rawDictionary, rawString, rawNumber, rawNull, rawBool. Initialising this properties for every single JSON can be expensive. I propose to use private `Content` enum with cases with associated values for every JSON type option. With this approach it is also possible to optimise how underlying values are accessed and we receive protection from type-value inconsistency.

 - What code was refactored / updated to support this change?
Updated how content of JSON is stored, changed object property behaviour, collection conformance + minor changes.

Performance tests report that:
- init works 20% faster
- object method's duration did not change
- array lookup works 43% faster
- dictionary lookup works 39% faster
- raw string method is not affected
- large dictionary lookup works 62% faster
- dictionary lookup with long path works 52% faster

Checklist:

 - [ ] Does this have tests?
One additional test of dictionary lookup performance has been added. Every piece of updated logic is already being tested.

 - [ ] Does this have documentation?
Documentation is provided for all new types / properties / functions.

 - [ ] Does this break the public API (Requires major version bump)?
One amazing thing about this update is that public API is not affected. Also JSON-related logic doesn't change, only implementation does.

 - [ ] Is this a new feature (Requires minor version bump)?
There are plenty of changes, version should be bumped.
