### PR TITLE
Correct fix for #1041 and #1038

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -1212,7 +1212,7 @@ public func > (lhs: JSON, rhs: JSON) -> Bool {
 public func < (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber .< rhs.rawNumber
+    case (.number, .number): return lhs.rawNumber < rhs.rawNumber
     case (.string, .string): return lhs.rawString < rhs.rawString
     default:                 return false
     }
@@ -1250,7 +1250,7 @@ func != (lhs: NSNumber, rhs: NSNumber) -> Bool {
     return !(lhs == rhs)
 }
 
-func .< (lhs: NSNumber, rhs: NSNumber) -> Bool {
+func < (lhs: NSNumber, rhs: NSNumber) -> Bool {
 
     switch (lhs.isBool, rhs.isBool) {
     case (false, true): return false

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -1212,7 +1212,7 @@ public func > (lhs: JSON, rhs: JSON) -> Bool {
 public func < (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber < rhs.rawNumber
+    case (.number, .number): return lhs.rawNumber .< rhs.rawNumber
     case (.string, .string): return lhs.rawString < rhs.rawString
     default:                 return false
     }
@@ -1236,6 +1236,8 @@ extension NSNumber {
     }
 }
 
+#if os(Linux)
+#else
 func == (lhs: NSNumber, rhs: NSNumber) -> Bool {
     switch (lhs.isBool, rhs.isBool) {
     case (false, true): return false
@@ -1248,7 +1250,7 @@ func != (lhs: NSNumber, rhs: NSNumber) -> Bool {
     return !(lhs == rhs)
 }
 
-func < (lhs: NSNumber, rhs: NSNumber) -> Bool {
+func .< (lhs: NSNumber, rhs: NSNumber) -> Bool {
 
     switch (lhs.isBool, rhs.isBool) {
     case (false, true): return false
@@ -1283,6 +1285,7 @@ func >= (lhs: NSNumber, rhs: NSNumber) -> Bool {
     default:            return lhs.compare(rhs) != .orderedAscending
     }
 }
+#endif
 
 public enum writingOptionsKeys {
 	case jsonSerialization


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
none. It just removes the duplicated code from Linux version (NSNumber comparators)
 - What code was refactored / updated to support this change?
Linux support
 - What issues are related to this PR? Or why was this change introduced?
#1041 and #1038
