### PR TITLE
bump deployment targets for Xcode 14.3

### DIFF
--- a/SwiftyJSON.podspec
+++ b/SwiftyJSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "SwiftyJSON"
-  s.version     = "5.0.1"
+  s.version     = "5.0.2"
   s.summary     = "SwiftyJSON makes it easy to deal with JSON data in Swift"
   s.homepage    = "https://github.com/SwiftyJSON/SwiftyJSON"
   s.license     = { :type => "MIT" }
@@ -8,8 +8,8 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.swift_version = "5.0"
-  s.osx.deployment_target = "10.9"
-  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.13"
+  s.ios.deployment_target = "16.1"
   s.watchos.deployment_target = "3.0"
   s.tvos.deployment_target = "9.0"
   s.source   = { :git => "https://github.com/SwiftyJSON/SwiftyJSON.git", :tag => s.version }


### PR DESCRIPTION
Xcode 14.3 fails to link applications when a framework has a macOS deployment target earlier than 10.13 or an iOS deployment target earlier than 16.1. (As of April 2023 apps built for earlier than iOS 16.1 cannot be submitted to the app store.) The linker will fail with an error like this:

`ld: file not found: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_macosx.a`

Simply increasing the deployment target in the Podspec file is sufficient to fix the error.