### PR TITLE
Fix some typos

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -571,7 +571,7 @@ extension JSON: Swift.RawRepresentable {
 
 	public func rawString(_ options: [writingOptionsKeys: Any]) -> String? {
 		let encoding = options[.encoding] as? String.Encoding ?? String.Encoding.utf8
-		let maxObjectDepth = options[.maxObjextDepth] as? Int ?? 10
+		let maxObjectDepth = options[.maxObjectDepth] as? Int ?? 10
 		do {
 			return try _rawString(encoding, options: options, maxObjectDepth: maxObjectDepth)
 		} catch {
@@ -1287,7 +1287,7 @@ func >= (lhs: NSNumber, rhs: NSNumber) -> Bool {
 public enum writingOptionsKeys {
 	case jsonSerialization
 	case castNilToNSNull
-	case maxObjextDepth
+	case maxObjectDepth
 	case encoding
 }
 

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -257,7 +257,7 @@ public struct JSON {
     public static var null: JSON { return JSON(NSNull()) }
 }
 
-/// Private method to unwarp an object recursively
+/// Private method to unwrap an object recursively
 private func unwrap(_ object: Any) -> Any {
     switch object {
     case let json as JSON:


### PR DESCRIPTION
Fix two typos.

1. unw `ar` p -> unwrap
2. maxObje `x` tDepth -> maxObjectDepth