### PR TITLE
Update rule in .swiftlint.yml to resolve a warning

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,7 @@
 disabled_rules:
   - force_cast
   - force_try
-  - variable_name
+  - identifier_name
   - type_name
   - file_length
   - line_length


### PR DESCRIPTION
## Resolve SwiftLint warning: `'variable_name' has been renamed to 'identifier_name' and will be completely removed in a future release.`

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

- What behavior was changed?
   - A SwiftLint rule was updated to use its new name. This is a refactor and does not affect the runtime behavior.
- What code was refactored / updated to support this change?
   - Only `swiftlint.yml` was updated.
- What issues are related to this PR? Or why was this change introduced?
   - Resolve a SwiftLint warning when running `swiftlint` on a project build that uses this dependency

Checklist - While not every PR needs it, new features should consider this list:

- [ ] Does this have tests?
  - n/a
- [ ] Does this have documentation?
  - n/a
- [ ] Does this break the public API (Requires major version bump)?
  - no
- [ ] Is this a new feature (Requires minor version bump)?
  - This is not a functional change. I will leave it up to the maintainers to decide if it really needs to be released by itself. But I think there should not be any issues as long as it makes it in to the next release.