### PR TITLE
Remove spam URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,5 +556,4 @@ provider.request(.showProducts) { result in
 
 ## SwiftyJSON Model Generator
 Tools to generate SwiftyJSON Models
-* [JSON Cafe](http://www.jsoncafe.com/)
 * [JSON Export](https://github.com/Ahmed-Ali/JSONExport)


### PR DESCRIPTION
URL is outdated and leads to spammy/phishy site through redirects.