### PR TITLE
Big performance improvement on JSON setter and getter

### DIFF
--- a/Tests/SwiftJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftJSONTests/PerformanceTests.swift
@@ -134,4 +134,66 @@ class PerformanceTests: XCTestCase {
             }
         }
     }
+    
+    func testArrayStackAccessPerformance() {
+        guard let json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
+        
+        self.measure {
+            for _ in 1...10_000 {
+                autoreleasepool {
+                    let string = json[0]["user"]["entities"]["url"]["urls"][0]["indices"]
+                    XCTAssertTrue(string.exists())
+                }
+            }
+        }
+    }
+    
+    func testBigArrayAccessPerformance() {
+        guard let json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
+        
+        self.measure {
+            for _ in 1...10_000 {
+                autoreleasepool {
+                    let string = json[0, "user", "entities", "url", "urls", 0, "indices"]
+                    XCTAssertTrue(string.exists())
+                }
+            }
+        }
+    }
+    
+    func testArrayStackWritePerformance() {
+        guard var json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
+        
+        self.measure {
+            for _ in 1...10_000 {
+                autoreleasepool {
+                    json[0]["user"]["entities"]["url"]["urls"][0]["indices"][0] = "hi"
+                }
+            }
+        }
+    }
+    
+    func testBigArrayWritePerformance() {
+        guard var json = try? JSON(data: self.testData) else {
+            XCTFail("Unable to parse testData")
+            return
+        }
+        
+        self.measure {
+            for _ in 1...10_000 {
+                autoreleasepool {
+                    json[0, "user", "entities", "url", "urls", 0, "indices"] = "hi"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hey it's me again! I'm back with some big performance improvements (up to more than 17x faster property access)!

When accessing sub-properties of a JSON struct (i.e. `json[0, "user", "entities", "url", "urls", 0, "indices"]` or `json[0]["user"]["entities"]["url"]["urls"][0]["indices"][0]`), SwiftyJSON was creating a new JSON structure for each sub-property (so for the first element of the array, it's "user" property and so on). This was a problem because the whole initialisation was done, `JSON(jsonObject:)`, for every sub-property even if we don't need them. 

We can't really anticipate the next-accessed property when using `["user"]...[0]`, but we can with `[0, ..., "indices"]`, so why bothering creating a new JSON struct n times? (`path.reduce(self) { $0[sub: $1] }`)

With this PR, properties are now accessed directly from the `rawDictionary` or the `rawArray` and their children, without creating a JSON struct every time, only for the final value.

The same applies to writing, where new JSON structures would also be created. The PR uses a new internal recursive set method on Arrays and Dictionaries to set the properties deep in the JSON structure more easily.

Measurements (10'000):

```swift
// array stack access 0.6187401250062976 -> 0.5908405833179131 => 4.6% faster
let _ = json[0]["user"]["entities"]["url"]["urls"][0]["indices"]

// array stack write 1.6944384166854434 -> 0.6044779583462514 => 180% faster
json[0]["user"]["entities"]["url"]["urls"][0]["indices"][0] = "hi"

// big array access 0.599869875004515 -> 0.03438512497814372 => 1744% faster (!)
let _ = json[0, "user", "entities", "url", "urls", 0, "indices"]

// big array write 0.5728218749864027 -> 0.07645037499605678 => 649% faster
json[0, "user", "entities", "url", "urls", 0, "indices"] = "hi"
```
where array stack refers to `[x][y]...` and big array `[x,y,...]`.

In my [use case](https://github.com/b5i/YouTubeKit), updating the version of SwiftyJSON and making sure all the accesses were using "big array" format improved by 30% the speed of my processing.

Let me know what you think of this PR and if any adjustments are needed!