### PR TITLE
Correct fix for #1041 and #1038

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -1160,7 +1160,7 @@ extension JSON: Swift.Comparable {}
 public func == (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber == rhs.rawNumber
+    case (.number, .number): return eq(lhs.rawNumber, rhs.rawNumber)
     case (.string, .string): return lhs.rawString == rhs.rawString
     case (.bool, .bool):     return lhs.rawBool == rhs.rawBool
     case (.array, .array):   return lhs.rawArray as NSArray == rhs.rawArray as NSArray
@@ -1173,7 +1173,7 @@ public func == (lhs: JSON, rhs: JSON) -> Bool {
 public func <= (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber <= rhs.rawNumber
+    case (.number, .number): return le(lhs.rawNumber, rhs.rawNumber)
     case (.string, .string): return lhs.rawString <= rhs.rawString
     case (.bool, .bool):     return lhs.rawBool == rhs.rawBool
     case (.array, .array):   return lhs.rawArray as NSArray == rhs.rawArray as NSArray
@@ -1186,7 +1186,7 @@ public func <= (lhs: JSON, rhs: JSON) -> Bool {
 public func >= (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber >= rhs.rawNumber
+    case (.number, .number): return ge(lhs.rawNumber, rhs.rawNumber)
     case (.string, .string): return lhs.rawString >= rhs.rawString
     case (.bool, .bool):     return lhs.rawBool == rhs.rawBool
     case (.array, .array):   return lhs.rawArray as NSArray == rhs.rawArray as NSArray
@@ -1199,7 +1199,7 @@ public func >= (lhs: JSON, rhs: JSON) -> Bool {
 public func > (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber > rhs.rawNumber
+    case (.number, .number): return gt(lhs.rawNumber, rhs.rawNumber)
     case (.string, .string): return lhs.rawString > rhs.rawString
     default:                 return false
     }
@@ -1208,7 +1208,7 @@ public func > (lhs: JSON, rhs: JSON) -> Bool {
 public func < (lhs: JSON, rhs: JSON) -> Bool {
 
     switch (lhs.type, rhs.type) {
-    case (.number, .number): return lhs.rawNumber < rhs.rawNumber
+    case (.number, .number): return lt(lhs.rawNumber, rhs.rawNumber)
     case (.string, .string): return lhs.rawString < rhs.rawString
     default:                 return false
     }
@@ -1232,7 +1232,7 @@ extension NSNumber {
     }
 }
 
-func == (lhs: NSNumber, rhs: NSNumber) -> Bool {
+func eq(_ lhs: NSNumber, _ rhs: NSNumber) -> Bool {
     switch (lhs.isBool, rhs.isBool) {
     case (false, true): return false
     case (true, false): return false
@@ -1240,11 +1240,11 @@ func == (lhs: NSNumber, rhs: NSNumber) -> Bool {
     }
 }
 
-func != (lhs: NSNumber, rhs: NSNumber) -> Bool {
+func neq(_ lhs: NSNumber, _ rhs: NSNumber) -> Bool {
     return !(lhs == rhs)
 }
 
-func < (lhs: NSNumber, rhs: NSNumber) -> Bool {
+func lt(_ lhs: NSNumber, _ rhs: NSNumber) -> Bool {
 
     switch (lhs.isBool, rhs.isBool) {
     case (false, true): return false
@@ -1253,7 +1253,7 @@ func < (lhs: NSNumber, rhs: NSNumber) -> Bool {
     }
 }
 
-func > (lhs: NSNumber, rhs: NSNumber) -> Bool {
+func gt(_ lhs: NSNumber, _ rhs: NSNumber) -> Bool {
 
     switch (lhs.isBool, rhs.isBool) {
     case (false, true): return false
@@ -1262,7 +1262,7 @@ func > (lhs: NSNumber, rhs: NSNumber) -> Bool {
     }
 }
 
-func <= (lhs: NSNumber, rhs: NSNumber) -> Bool {
+func le(_ lhs: NSNumber, _ rhs: NSNumber) -> Bool {
 
     switch (lhs.isBool, rhs.isBool) {
     case (false, true): return false
@@ -1271,7 +1271,7 @@ func <= (lhs: NSNumber, rhs: NSNumber) -> Bool {
     }
 }
 
-func >= (lhs: NSNumber, rhs: NSNumber) -> Bool {
+func ge(_ lhs: NSNumber, _ rhs: NSNumber) -> Bool {
 
     switch (lhs.isBool, rhs.isBool) {
     case (false, true): return false


### PR DESCRIPTION
This pull request fixes compatibility issues with the Swift toolchain for Linux described in #1041 and #1038, but does so in a safer and more reliable way, as suggested in the latest comments on PR #1083.

The root cause of these issues is that the open-source version of the Foundation library, SwiftFoundation, implements its own comparison operators for the NSNumber type. This causes ambiguity with the comparison operators implemented in SwiftyJSON. To avoid this, we replace SwiftyJSON’s comparison operators with simple functions and use them for all platforms, without conditional compilation or relying on different comparison operators for each platform. This approach is safer because it avoids depending on SwiftFoundation’s operator implementations.

 **- Does this have tests?**
Existing tests already cover the changes in this PR.

 **- Does this have documentation?**
No additional documentation is required.

 **- Does this break the public API (Requires major version bump)?**
No, it does not break the public API.

 **- Is this a new feature (Requires minor version bump)?**
No, this is not a new feature and does not require a minor version bump.