### PR TITLE
Fix Xcode test file references and Bundle.module compatibility

### DIFF
--- a/SwiftyJSON.xcodeproj/project.pbxproj
+++ b/SwiftyJSON.xcodeproj/project.pbxproj
@@ -278,7 +278,7 @@
 				2E4FEFEB19575BE100351305 /* Supporting Files */,
 			);
 			name = Tests;
-			path = Tests/Tes;
+			path = Tests/SwiftJSONTests;
 			sourceTree = "<group>";
 		};
 		2E4FEFEB19575BE100351305 /* Supporting Files */ = {

--- a/Tests/SwiftJSONTests/BaseTests.swift
+++ b/Tests/SwiftJSONTests/BaseTests.swift
@@ -31,9 +31,12 @@ class BaseTests: XCTestCase {
 
         super.setUp()
 
-//        let file = "./Tests/Tes/Tests.json"
-//        self.testData = try? Data(contentsOf: URL(fileURLWithPath: file))
-        if let file = Bundle.module.url(forResource: "Tests", withExtension: "json") {
+        #if SWIFT_PACKAGE
+        let testBundle = Bundle.module
+        #else
+        let testBundle = Bundle(for: BaseTests.self)
+        #endif
+        if let file = testBundle.url(forResource: "Tests", withExtension: "json") {
             self.testData = try? Data(contentsOf: file)
         } else {
             XCTFail("Can't find the test JSON file")

--- a/Tests/SwiftJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftJSONTests/PerformanceTests.swift
@@ -30,7 +30,12 @@ class PerformanceTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        if let file = Bundle.module.url(forResource: "Tests", withExtension: "json") {
+        #if SWIFT_PACKAGE
+        let testBundle = Bundle.module
+        #else
+        let testBundle = Bundle(for: PerformanceTests.self)
+        #endif
+        if let file = testBundle.url(forResource: "Tests", withExtension: "json") {
             self.testData = try? Data(contentsOf: file)
         } else {
             XCTFail("Can't find the test JSON file")

--- a/Tests/SwiftJSONTests/SequenceTypeTests.swift
+++ b/Tests/SwiftJSONTests/SequenceTypeTests.swift
@@ -28,7 +28,12 @@ class SequenceTypeTests: XCTestCase {
     var testData: Data?
 
     func testJSONFile() {
-        if let file = Bundle.module.url(forResource: "Tests", withExtension: "json") {
+        #if SWIFT_PACKAGE
+        let testBundle = Bundle.module
+        #else
+        let testBundle = Bundle(for: SequenceTypeTests.self)
+        #endif
+        if let file = testBundle.url(forResource: "Tests", withExtension: "json") {
             self.testData = try? Data(contentsOf: file)
             guard let json = try? JSON(data: self.testData!) else {
                 XCTFail("Unable to parse the data")


### PR DESCRIPTION
# Summary
This PR fixes two issues affecting tests in Xcode/workspace builds: 

1. Broken red test file references in Xcode due to an incorrect Tests group path.
2. `Bundle.module` build error in Xcode project tests (Type 'Bundle' has no member 'module').

# Changes

* Updated `project.pbxproj` : Changed `Tests` group path from:
  * `Tests/Tes` -> `Tests/SwiftJSONTests`
* Tests : Added conditional bundle lookup
  * SwiftPM : `Bundle.module` (not changed)
  * Xcode project target : `Bundle(for: <TestClass>.self)`

# Result

* Test files under Tests/SwiftJSONTests are resolved correctly in Xcode.
* Tests compile/run in both SwiftPM CLI and Xcode project environments