### PR TITLE
Use let in RawRepresentableTests

### DIFF
--- a/Tests/SwiftJSONTests/RawRepresentableTests.swift
+++ b/Tests/SwiftJSONTests/RawRepresentableTests.swift
@@ -26,7 +26,7 @@ import SwiftyJSON
 class RawRepresentableTests: XCTestCase {
 
     func testNumber() {
-        var json: JSON = JSON(rawValue: 948394394.347384 as NSNumber)!
+        let json: JSON = JSON(rawValue: 948394394.347384 as NSNumber)!
         XCTAssertEqual(json.int!, 948394394)
         XCTAssertEqual(json.intValue, 948394394)
         XCTAssertEqual(json.double!, 948394394.347384)
@@ -46,11 +46,11 @@ class RawRepresentableTests: XCTestCase {
     }
 
     func testBool() {
-        var jsonTrue: JSON = JSON(rawValue: true as NSNumber)!
+        let jsonTrue: JSON = JSON(rawValue: true as NSNumber)!
         XCTAssertEqual(jsonTrue.bool!, true)
         XCTAssertEqual(jsonTrue.boolValue, true)
 
-        var jsonFalse: JSON = JSON(rawValue: false)!
+        let jsonFalse: JSON = JSON(rawValue: false)!
         XCTAssertEqual(jsonFalse.bool!, false)
         XCTAssertEqual(jsonFalse.boolValue, false)
 


### PR DESCRIPTION
What changed:

Changed three immutable local JSON values in `RawRepresentableTests` from `var` to `let`.

Why:

This removes Swift compiler warnings about variables that are never mutated, without changing test behavior or public API.

Checklist:

- [x] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?

Validation:

- `swift test` baseline passed before the change: 149 tests
- `swift test --filter RawRepresentableTests`
- `swift build --build-tests`
- `git diff --check`