### PR TITLE
Escape strings in raw JSON output

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -538,6 +538,32 @@ extension JSON: Swift.ExpressibleByArrayLiteral {
 
 // MARK: - Raw
 
+private func escapeJSONString(_ string: String) -> String {
+    string.unicodeScalars.reduce(into: "") { result, scalar in
+        switch scalar.value {
+        case 0x08:
+            result += "\\b"
+        case 0x09:
+            result += "\\t"
+        case 0x0A:
+            result += "\\n"
+        case 0x0C:
+            result += "\\f"
+        case 0x0D:
+            result += "\\r"
+        case 0x22:
+            result += "\\\""
+        case 0x5C:
+            result += "\\\\"
+        case 0x00 ... 0x1F:
+            let hex = String(scalar.value, radix: 16, uppercase: true)
+            result += "\\u" + String(repeating: "0", count: 4 - hex.count) + hex
+        default:
+            result.append(contentsOf: String(scalar))
+        }
+    }
+}
+
 extension JSON: Swift.RawRepresentable {
 
     public init?(rawValue: Any) {
@@ -596,10 +622,10 @@ extension JSON: Swift.RawRepresentable {
 				}
 				let body = try dict.keys.map { key throws -> String in
 					guard let value = dict[key] else {
-						return "\"\(key)\": null"
+						return "\"\(escapeJSONString(key))\": null"
 					}
 					guard let unwrappedValue = value else {
-						return "\"\(key)\": null"
+						return "\"\(escapeJSONString(key))\": null"
 					}
 
 					let nestedValue = JSON(unwrappedValue)
@@ -607,9 +633,9 @@ extension JSON: Swift.RawRepresentable {
 						throw SwiftyJSONError.elementTooDeep
 					}
 					if nestedValue.type == .string {
-						return "\"\(key)\": \"\(nestedString.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
+						return "\"\(escapeJSONString(key))\": \"\(escapeJSONString(nestedString))\""
 					} else {
-						return "\"\(key)\": \(nestedString)"
+						return "\"\(escapeJSONString(key))\": \(nestedString)"
 					}
 				}
 
@@ -638,7 +664,7 @@ extension JSON: Swift.RawRepresentable {
                         throw SwiftyJSONError.invalidJSON
                     }
                     if nestedValue.type == .string {
-                        return "\"\(nestedString.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
+                        return "\"\(escapeJSONString(nestedString))\""
                     } else {
                         return nestedString
                     }

--- a/Tests/SwiftJSONTests/RawTests.swift
+++ b/Tests/SwiftJSONTests/RawTests.swift
@@ -20,6 +20,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import Foundation
 import XCTest
 import SwiftyJSON
 
@@ -101,5 +102,23 @@ class RawTests: XCTestCase {
         let string = json.rawString()
         XCTAssertNotNil(data)
         XCTAssertNotNil(string)
+    }
+
+    func testRawStringEscapesKeysAndControlCharacters() {
+        let key = "key\"with\ncontrol"
+        let value = "line1\nline2\t\u{0001}\"\\"
+        let json: JSON = [key: value]
+
+        guard let raw = json.rawString([.castNilToNSNull: true]) else {
+            XCTFail("Expected a JSON string")
+            return
+        }
+
+        do {
+            let object = try JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: String]
+            XCTAssertEqual(object?[key], value)
+        } catch {
+            XCTFail("Expected valid JSON, got error: \(error)")
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Escape JSON object keys and string values consistently in the castNilToNSNull serialization path.
- Cover quotes, backslashes, newlines, tabs, and control characters with a JSONSerialization round-trip regression test.

Fixes #1200

## Testing

- git diff --check
- swift build passed
- Built-library smoke test passed and JSONSerialization successfully parsed the generated output
- swift test --filter RawTests was blocked because XCTest is unavailable in the current CommandLineTools environment